### PR TITLE
Split rustfix into two crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Automatically apply the suggestions made by rustc"
 repository = "https://github.com/killercup/rustfix"
 documentation = "https://docs.rs/rustfix"
 readme = "README.md"
-version = "0.1.0"
+version = "0.2.0"
 exclude = [
     "etc/*",
     "examples/*",
@@ -17,8 +17,6 @@ exclude = [
 ]
 
 [dependencies]
-clap = "2.9.2"
-colored = "1.2.0"
 quick-error = "1.2.1"
 serde = "1.0"
 serde_json = "1.0"
@@ -30,3 +28,11 @@ env_logger = "0.5.0-rc.1"
 log = "0.4.1"
 pretty_assertions = "0.4.1"
 tempdir = "0.3.5"
+
+[workspace]
+members = [
+    "cargo-fix",
+]
+
+[patch.crates-io]
+rustfix = { path = "." }

--- a/cargo-fix/Cargo.toml
+++ b/cargo-fix/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cargo-fix"
+version = "0.2.0"
+authors = ["Pascal Hertleif <killercup@gmail.com>"]
+
+[dependencies]
+clap = "2.9.2"
+colored = "1.2.0"
+quick-error = "1.2.1"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+rustfix = "0.1.0"

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -55,7 +55,14 @@ const ALIASES: &[(&str, &[&str])] = &[
 ];
 
 fn try_main() -> Result<(), ProgramError> {
-    let matches = App::new("rustfix")
+    // Quickfix to be usable as rustfix as well as cargo-fix
+    let args = if ::std::env::args_os().nth(1).map(|x| &x == "fix").unwrap_or(false) {
+        ::std::env::args_os().skip(1)
+    } else {
+        ::std::env::args_os().skip(0)
+    };
+
+    let matches = App::new("cargo-fix")
         .about("Automatically apply suggestions made by rustc")
         .version(crate_version!())
         .arg(Arg::with_name("clippy")
@@ -72,7 +79,7 @@ fn try_main() -> Result<(), ProgramError> {
             .long("file")
             .takes_value(true)
             .help("Load errors from the given JSON file (produced by `cargo build --message-format=json`)"))
-        .get_matches();
+        .get_matches_from(args);
 
     let mut extra_args = Vec::new();
 

--- a/src/bin/cargo-fix.rs
+++ b/src/bin/cargo-fix.rs
@@ -1,4 +1,0 @@
-// horrible hack to get cargo to not complain about both
-// the `cargo-fix` and `rustfix` targets to point to the
-// same source file
-include!("../main.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ extern crate serde_derive;
 extern crate serde_json;
 
 use std::collections::HashSet;
-use std::error::Error;
 
 pub mod diagnostics;
 use diagnostics::{Diagnostic, DiagnosticSpan};


### PR DESCRIPTION
- rustfix stays as the library crate
- cargo-fix becomes the new binary crate