### PR TITLE
Rewrite the `cargo fix` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = [
 ]
 
 [dependencies]
-quick-error = "1.2.1"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -33,6 +32,3 @@ tempdir = "0.3.5"
 members = [
     "cargo-fix",
 ]
-
-[patch.crates-io]
-rustfix = { path = "." }

--- a/cargo-fix/Cargo.toml
+++ b/cargo-fix/Cargo.toml
@@ -17,6 +17,7 @@ failure = "0.1"
 rustfix = { path = "..", version = "0.2" }
 serde_json = "1"
 log = "0.4"
+env_logger = { version = "0.5", default-features = false }
 
 [dev-dependencies]
 difference = "2"

--- a/cargo-fix/Cargo.toml
+++ b/cargo-fix/Cargo.toml
@@ -8,11 +8,16 @@ repository = "https://github.com/killercup/rustfix"
 documentation = "https://docs.rs/rustfix"
 readme = "README.md"
 
+[[bin]]
+name = "cargo-fix"
+test = false
+
 [dependencies]
-clap = "2.9.2"
-colored = "1.2.0"
-quick-error = "1.2.1"
-serde = "1.0"
-serde_json = "1.0"
-serde_derive = "1.0"
-rustfix = "0.2.0"
+failure = "0.1"
+rustfix = { path = "..", version = "0.2" }
+serde_json = "1"
+log = "0.4"
+
+[dev-dependencies]
+difference = "2"
+url = "1"

--- a/cargo-fix/src/lock.rs
+++ b/cargo-fix/src/lock.rs
@@ -1,0 +1,163 @@
+//! An implementation of IPC locks, guaranteed to be released if a process dies
+//!
+//! This module implements a locking server/client where the main `cargo fix`
+//! process will start up a server and then all the client processes will
+//! connect to it. The main purpose of this file is to enusre that each crate
+//! (aka file entry point) is only fixed by one process at a time, currently
+//! concurrent fixes can't happen.
+//!
+//! The basic design here is to use a TCP server which is pretty portable across
+//! platforms. For simplicity it just uses threads as well. Clients connect to
+//! the main server, inform the server what its name is, and then wait for the
+//! server to give it the lock (aka write a byte).
+
+use std::collections::HashMap;
+use std::env;
+use std::io::{BufReader, BufRead, Read, Write};
+use std::net::{TcpStream, SocketAddr, TcpListener};
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+
+use failure::{Error, ResultExt};
+
+pub struct Server {
+    listener: TcpListener,
+    threads: HashMap<String, ServerClient>,
+    done: Arc<AtomicBool>,
+}
+
+pub struct StartedServer {
+    done: Arc<AtomicBool>,
+    addr: SocketAddr,
+    thread: Option<JoinHandle<()>>,
+}
+
+pub struct Client {
+    _socket: TcpStream,
+}
+
+struct ServerClient {
+    thread: Option<JoinHandle<()>>,
+    lock: Arc<Mutex<(bool, Vec<TcpStream>)>>,
+}
+
+impl Server {
+    pub fn new() -> Result<Server, Error> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .with_context(|_| "failed to bind TCP listener to manage locking")?;
+        env::set_var("__CARGO_FIX_SERVER", listener.local_addr()?.to_string());
+        Ok(Server {
+            listener,
+            threads: HashMap::new(),
+            done: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    pub fn start(self) -> Result<StartedServer, Error> {
+        let addr = self.listener.local_addr()?;
+        let done = self.done.clone();
+        let thread = thread::spawn(|| {
+            self.run();
+        });
+        Ok(StartedServer {
+            addr,
+            thread: Some(thread),
+            done,
+        })
+    }
+
+    fn run(mut self) {
+        while let Ok((client, _)) = self.listener.accept() {
+            if self.done.load(Ordering::SeqCst) {
+                break
+            }
+
+            // Learn the name of our connected client to figure out if it needs
+            // to wait for another process to release the lock.
+            let mut client = BufReader::new(client);
+            let mut name = String::new();
+            if client.read_line(&mut name).is_err() {
+                continue
+            }
+            let client = client.into_inner();
+
+            // If this "named mutex" is already registered and the thread is
+            // still going, put it on the queue. Otherwise wait on the previous
+            // thread and we'll replace it just below.
+            if let Some(t) = self.threads.get_mut(&name) {
+                let mut state = t.lock.lock().unwrap();
+                if state.0 {
+                    state.1.push(client);
+                    continue
+                }
+                drop(t.thread.take().unwrap().join());
+            }
+
+            let lock = Arc::new(Mutex::new((true, vec![client])));
+            let lock2 = lock.clone();
+            let thread = thread::spawn(move || {
+                loop {
+                    let mut client = {
+                        let mut state = lock2.lock().unwrap();
+                        if state.1.len() == 0 {
+                            state.0 = false;
+                            break
+                        } else {
+                            state.1.remove(0)
+                        }
+                    };
+                    // Inform this client that it now has the lock and wait for
+                    // it to disconnect by waiting for EOF.
+                    if client.write_all(&[1]).is_err() {
+                        continue
+                    }
+                    let mut dst = Vec::new();
+                    drop(client.read_to_end(&mut dst));
+                }
+            });
+
+            self.threads.insert(name, ServerClient {
+                thread: Some(thread),
+                lock,
+            });
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        for (_, mut client) in self.threads.drain() {
+            if let Some(thread) = client.thread.take() {
+                drop(thread.join());
+            }
+        }
+    }
+}
+
+impl Drop for StartedServer {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::SeqCst);
+        // Ignore errors here as this is largely best-effort
+        if TcpStream::connect(&self.addr).is_err() {
+            return
+        }
+        drop(self.thread.take().unwrap().join());
+    }
+}
+
+impl Client {
+    pub fn lock(name: &str) -> Result<Client, Error> {
+        let addr = env::var("__CARGO_FIX_SERVER")
+            .map_err(|_| format_err!("locking strategy misconfigured"))?;
+        let mut client = TcpStream::connect(&addr)
+            .with_context(|_| "failed to connect to parent lock server")?;
+        client.write_all(name.as_bytes())
+            .and_then(|_| client.write_all(b"\n"))
+            .with_context(|_| "failed to write to lock server")?;
+        let mut buf = [0];
+        client.read_exact(&mut buf)
+            .with_context(|_| "failed to acquire lock")?;
+        Ok(Client { _socket: client })
+    }
+}

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -105,6 +105,11 @@ fn cargo_fix_rustc() -> Result<(), Error> {
 }
 
 fn rustfix_crate(rustc: &Path, filename: &str) -> Result<(), Error> {
+    // If not empty, filter by these lints
+    //
+    // TODO: Implement a way to specify this
+    let only = HashSet::new();
+
     // First up we want to make sure that each crate is only checked by one
     // process at a time. If two invocations concurrently check a crate then
     // it's likely to corrupt it.
@@ -125,7 +130,6 @@ fn rustfix_crate(rustc: &Path, filename: &str) -> Result<(), Error> {
     // there are compiler errors.
     let stderr = str::from_utf8(&output.stderr)
         .map_err(|_| format_err!("failed to parse rustc stderr as utf-8"))?;
-    let only = HashSet::new();
     let suggestions = stderr.lines()
         .filter(|x| !x.is_empty())
 

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -4,6 +4,7 @@ extern crate rustfix;
 extern crate serde_json;
 #[macro_use]
 extern crate log;
+extern crate env_logger;
 
 use std::collections::{HashSet, HashMap};
 use std::env;
@@ -19,6 +20,7 @@ use failure::{Error, ResultExt};
 mod lock;
 
 fn main() {
+    env_logger::init();
     let result = if env::var("__CARGO_FIX_NOW_RUSTC").is_ok() {
         cargo_fix_rustc()
     } else {

--- a/cargo-fix/tests/all/dependencies.rs
+++ b/cargo-fix/tests/all/dependencies.rs
@@ -1,0 +1,100 @@
+use super::project;
+
+#[test]
+fn fix_path_deps() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = { path = 'bar' }
+
+                [workspace]
+            "#
+        )
+        .file("src/lib.rs", r#"
+            extern crate bar;
+
+            fn add(a: &u32) -> u32 {
+                a + 1
+            }
+
+            pub fn foo() -> u32 {
+                add(1) + add(1)
+            }
+        "#)
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+            "#
+        )
+        .file("bar/src/lib.rs", r#"
+            fn add(a: &u32) -> u32 {
+                a + 1
+            }
+
+            pub fn foo() -> u32 {
+                add(1) + add(1)
+            }
+        "#)
+        .build();
+
+    let stderr = "\
+[CHECKING] bar v0.1.0 (CWD/bar)
+[CHECKING] foo v0.1.0 (CWD)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo fix")
+        .stdout("")
+        .stderr(stderr)
+        .run();
+}
+
+#[test]
+fn do_not_fix_non_relevant_deps() {
+    let p = project()
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = { path = '../bar' }
+
+                [workspace]
+            "#
+        )
+        .file("foo/src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+            "#
+        )
+        .file("bar/src/lib.rs", r#"
+            fn add(a: &u32) -> u32 {
+                a + 1
+            }
+
+            pub fn foo() -> u32 {
+                add(1) + add(1)
+            }
+        "#)
+        .build();
+
+    p.expect_cmd("cargo fix")
+        .cwd("foo")
+        .status(101)
+        .run();
+}

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -1,0 +1,264 @@
+extern crate difference;
+extern crate url;
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str;
+use std::sync::atomic::*;
+use std::time::Instant;
+
+use difference::{Changeset, Difference};
+use url::Url;
+
+static CNT: AtomicUsize = ATOMIC_USIZE_INIT;
+thread_local!(static IDX: usize = CNT.fetch_add(1, Ordering::SeqCst));
+
+struct ProjectBuilder {
+    files: Vec<(String, String)>,
+}
+
+struct Project {
+    root: PathBuf,
+}
+
+fn project() -> ProjectBuilder {
+    ProjectBuilder {
+        files: Vec::new(),
+    }
+}
+
+fn root() -> PathBuf {
+    let idx = IDX.with(|x| *x);
+
+    let mut me = env::current_exe().unwrap();
+    me.pop(); // chop off exe name
+    me.pop(); // chop off `deps`
+    me.pop(); // chop off `debug` / `release`
+    me.push("generated-tests");
+    me.push(&format!("test{}", idx));
+    return me
+}
+
+impl ProjectBuilder {
+    fn file(&mut self, name: &str, contents: &str) -> &mut ProjectBuilder {
+        self.files.push((name.to_string(), contents.to_string()));
+        self
+    }
+
+    fn build(&mut self) -> Project {
+        if !self.files.iter().any(|f| f.0.ends_with("Cargo.toml")) {
+            let manifest = r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [workspace]
+            "#;
+            self.files.push(("Cargo.toml".to_string(), manifest.to_string()));
+        }
+        let root = root();
+        drop(fs::remove_dir_all(&root));
+        for &(ref file, ref contents) in self.files.iter() {
+            let dst = root.join(file);
+            fs::create_dir_all(dst.parent().unwrap()).unwrap();
+            fs::File::create(&dst).unwrap().write_all(contents.as_ref()).unwrap();
+        }
+        Project { root }
+    }
+}
+
+impl Project {
+    fn expect_cmd<'a>(&'a self, cmd: &'a str) -> ExpectCmd<'a> {
+        ExpectCmd {
+            project: self,
+            cmd: cmd,
+            stdout: None,
+            stdout_contains: Vec::new(),
+            stderr: None,
+            stderr_contains: Vec::new(),
+            status: 0,
+            ran: false,
+            cwd: None,
+        }
+    }
+}
+
+struct ExpectCmd<'a> {
+    ran: bool,
+    project: &'a Project,
+    cmd: &'a str,
+    stdout: Option<String>,
+    stdout_contains: Vec<String>,
+    stderr: Option<String>,
+    stderr_contains: Vec<String>,
+    status: i32,
+    cwd: Option<PathBuf>,
+}
+
+impl<'a> ExpectCmd<'a> {
+    fn status(&mut self, status: i32) -> &mut Self {
+        self.status = status;
+        self
+    }
+
+    fn cwd<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cwd = Some(self.project.root.join(path));
+        self
+    }
+
+    fn stdout(&mut self, s: &str) -> &mut Self {
+        self.stdout = Some(s.to_string());
+        self
+    }
+
+    fn stderr(&mut self, s: &str) -> &mut Self {
+        self.stderr = Some(s.to_string());
+        self
+    }
+
+    fn stderr_contains(&mut self, s: &str) -> &mut Self {
+        self.stderr_contains.push(s.to_string());
+        self
+    }
+
+    fn run(&mut self) {
+        self.ran = true;
+        let mut parts = self.cmd.split_whitespace();
+        let mut cmd = Command::new(parts.next().unwrap());
+        cmd.args(parts);
+        match self.cwd {
+            Some(ref p) => { cmd.current_dir(p); }
+            None => { cmd.current_dir(&self.project.root); }
+        }
+
+        let mut me = env::current_exe().unwrap();
+        me.pop(); // chop off exe name
+        me.pop(); // chop off `deps`
+
+        let mut new_path = Vec::new();
+        new_path.push(me);
+        new_path.extend(
+            env::split_paths(&env::var_os("PATH").unwrap_or(Default::default())),
+        );
+        cmd.env("PATH", env::join_paths(&new_path).unwrap());
+
+        println!("\n···················································");
+        println!("running {:?}", cmd);
+        let start = Instant::now();
+        let output = match cmd.output() {
+            Ok(output) => output,
+            Err(err) => panic!("failed to spawn: {}", err),
+        };
+        let dur = start.elapsed();
+        println!("dur: {}.{:03}ms", dur.as_secs(), dur.subsec_nanos() / 1_000_000);
+        println!("exit: {}", output.status);
+        if output.stdout.len() > 0 {
+            println!("stdout ---\n{}", String::from_utf8_lossy(&output.stdout));
+        }
+        if output.stderr.len() > 0 {
+            println!("stderr ---\n{}", String::from_utf8_lossy(&output.stderr));
+        }
+        println!("···················································");
+        let code = match output.status.code() {
+            Some(code) => code,
+            None => panic!("super extra failure: {}", output.status),
+        };
+        if code != self.status {
+            panic!("expected exit code `{}` got `{}`", self.status, code);
+        }
+        self.match_std(&output.stdout, &self.stdout, &self.stdout_contains);
+        self.match_std(&output.stderr, &self.stderr, &self.stderr_contains);
+    }
+
+    fn match_std(&self, actual: &[u8], expected: &Option<String>, contains: &[String]) {
+        let actual = match str::from_utf8(actual) {
+            Ok(s) => s,
+            Err(_) => panic!("std wasn't utf8"),
+        };
+        let actual = self.clean(actual);
+        if let Some(ref expected) = *expected {
+            diff(&self.clean(expected), &actual);
+        }
+        for s in contains {
+            let s = self.clean(s);
+            if actual.contains(&s) {
+                continue
+            }
+            println!("\nfailed to find contents within output stream\n\
+                      expected to find\n  {}\n\nwithin:\n\n{}\n\n",
+                     s,
+                     actual);
+            panic!("test failed");
+        }
+    }
+
+    fn clean(&self, s: &str) -> String {
+        let url = Url::from_file_path(&self.project.root).unwrap();
+        let s = s.replace("[CHECKING]", "    Checking")
+            .replace("[FINISHED]", "    Finished")
+            .replace("[COMPILING]", "   Compiling")
+            .replace(&url.to_string(), "CWD")
+            .replace(&self.project.root.display().to_string(), "CWD")
+            .replace("\\", "/");
+        let lines = s.lines()
+            .map(|s| {
+                let i = match s.find("target(s) in") {
+                    Some(i) => i,
+                    None => return s.to_string(),
+                };
+                if s.trim().starts_with("Finished") {
+                    s[..i].to_string()
+                } else {
+                    s.to_string()
+                }
+            });
+        let mut ret = String::new();
+        for (i, line) in lines.enumerate() {
+            if i != 0 {
+                ret.push_str("\n");
+            }
+            ret.push_str(&line);
+        }
+        ret
+    }
+}
+
+impl<'a> Drop for ExpectCmd<'a> {
+    fn drop(&mut self) {
+        if !self.ran {
+            panic!("forgot to run this command");
+        }
+    }
+}
+
+fn diff(expected: &str, actual: &str) {
+    let changeset = Changeset::new(expected.trim(), actual.trim(), "\n");
+
+    let mut different = false;
+    for diff in changeset.diffs {
+        let (prefix, diff) = match diff {
+            Difference::Same(_) => continue,
+            Difference::Add(add) => ("+", add),
+            Difference::Rem(rem) => ("-", rem),
+        };
+        if !different {
+            println!("differences found (+ == actual, - == expected):\n");
+            different = true;
+        }
+        for diff in diff.lines() {
+            println!("{} {}", prefix, diff);
+        }
+    }
+    if different {
+        println!("");
+        panic!("found some differences");
+    }
+}
+
+mod dependencies;
+mod smoke;
+mod subtargets;
+mod warnings;

--- a/cargo-fix/tests/all/smoke.rs
+++ b/cargo-fix/tests/all/smoke.rs
@@ -1,0 +1,89 @@
+use super::project;
+
+#[test]
+fn no_changes_necessary() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 (CWD)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo fix")
+        .stdout("")
+        .stderr(stderr)
+        .run();
+}
+
+#[test]
+fn fixes_missing_ampersand() {
+    let p = project()
+        .file("src/lib.rs", r#"
+            fn add(a: &u32) -> u32 {
+                a + 1
+            }
+
+            pub fn foo() -> u32 {
+                add(1)
+            }
+        "#)
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 (CWD)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo fix")
+        .stdout("")
+        .stderr(stderr)
+        .run();
+}
+
+#[test]
+fn fixes_two_missing_ampersands() {
+    let p = project()
+        .file("src/lib.rs", r#"
+            fn add(a: &u32) -> u32 {
+                a + 1
+            }
+
+            pub fn foo() -> u32 {
+                add(1) + add(1)
+            }
+        "#)
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 (CWD)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo fix")
+        .stdout("")
+        .stderr(stderr)
+        .run();
+}
+
+#[test]
+fn tricky_ampersand() {
+    let p = project()
+        .file("src/lib.rs", r#"
+            fn add(a: &u32) -> u32 {
+                a + 1
+            }
+
+            pub fn foo() -> u32 {
+                add(1) + add(1)
+            }
+        "#)
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 (CWD)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo fix")
+        .stdout("")
+        .stderr(stderr)
+        .run();
+}

--- a/cargo-fix/tests/all/subtargets.rs
+++ b/cargo-fix/tests/all/subtargets.rs
@@ -1,0 +1,69 @@
+use super::project;
+
+#[test]
+fn fixes_missing_ampersand() {
+    let p = project()
+        .file("src/main.rs", r#"
+            fn add(a: &u32) -> u32 { a + 1 }
+            fn main() { add(1); }
+        "#)
+        .file("src/lib.rs", r#"
+            fn add(a: &u32) -> u32 { a + 1 }
+            pub fn foo() -> u32 { add(1) }
+
+            #[test]
+            pub fn foo2() { add(1); }
+        "#)
+        .file("tests/a.rs", r#"
+            fn add(a: &u32) -> u32 { a + 1 }
+            #[test]
+            pub fn foo() { add(1); }
+        "#)
+        .file("examples/foo.rs", r#"
+            fn add(a: &u32) -> u32 { a + 1 }
+            fn main() { add(1); }
+        "#)
+        .file("build.rs", r#"
+            fn add(a: &u32) -> u32 { a + 1 }
+            fn main() { add(1); }
+        "#)
+        .build();
+
+    let stderr = "\
+[COMPILING] foo v0.1.0 (CWD)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo fix --all-targets").stdout("").stderr(stderr).run();
+    p.expect_cmd("cargo build").run();
+    p.expect_cmd("cargo test").run();
+}
+
+#[test]
+fn fix_features() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [features]
+                bar = []
+
+                [workspace]
+            "#
+        )
+        .file("src/lib.rs", r#"
+            fn add(a: &u32) -> u32 { a + 1 }
+
+            #[cfg(feature = "bar")]
+            pub fn foo() -> u32 { add(1) }
+        "#)
+        .build();
+
+    p.expect_cmd("cargo fix").run();
+    p.expect_cmd("cargo build").run();
+    p.expect_cmd("cargo fix --features bar").run();
+    p.expect_cmd("cargo build --features bar").run();
+}

--- a/cargo-fix/tests/all/warnings.rs
+++ b/cargo-fix/tests/all/warnings.rs
@@ -1,0 +1,15 @@
+use super::project;
+
+#[test]
+fn shows_warnings() {
+    let p = project()
+        .file("src/lib.rs", r#"
+            use std::default::Default;
+
+            pub fn foo() {
+            }
+        "#)
+        .build();
+
+    p.expect_cmd("cargo fix").stderr_contains("warning: unused import").run();
+}


### PR DESCRIPTION
This commit starts rewritign the `cargo fix` command in line with the recent
discussions around the edition. The main changes here are:

* The interactivity of `cargo fix` is removed
* Executing `cargo fix` is now a thin veneer over `cargo check`
* Fixes are automatically applied when it looks very likely to succeed if we
  apply them.
* Fixes are only applied to the local workspace rather than upstream crates as
  well.

There's still a number of missing features to fill out marked with a few TODO
here and there but the test suite is already looking relatively solid. I think
we've got a long way to go here but this is hopefully a good start in the
direction of where we want to go.