### PR TITLE
Use a more clever way to replace parts of a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - nightly
 script:
   - cargo test --all
+  - cargo test --all -- --ignored
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ exclude = [
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-replace-rs = { git = "https://github.com/killercup/replace-rs" }
 failure = "0.1.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ env_logger = "0.5.0-rc.1"
 log = "0.4.1"
 pretty_assertions = "0.4.1"
 tempdir = "0.3.5"
+proptest = "0.7.0"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ exclude = [
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+replace-rs = { git = "https://github.com/killercup/replace-rs" }
+failure = "0.1.1"
 
 [dev-dependencies]
 duct = "0.8.2"

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -177,7 +177,7 @@ fn rustfix_crate(rustc: &Path, filename: &str) -> Result<(), Error> {
         }
         debug!("applying {} fixes to {}", suggestions.len(), file);
 
-        let new_code = rustfix::apply_suggestions(&code, &suggestions);
+        let new_code = rustfix::apply_suggestions(&code, &suggestions)?;
         File::create(&file)
             .and_then(|mut f| f.write_all(new_code.as_bytes()))
             .with_context(|_| format!("failed to write file `{}`", file))?;

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -2,8 +2,8 @@ extern crate difference;
 extern crate url;
 
 use std::env;
-use std::fs;
-use std::io::Write;
+use std::fs::{self, File};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
@@ -83,6 +83,15 @@ impl Project {
             ran: false,
             cwd: None,
         }
+    }
+
+    fn read(&self, path: &str) -> String {
+        let mut ret = String::new();
+        File::open(self.root.join(path))
+            .unwrap()
+            .read_to_string(&mut ret)
+            .unwrap();
+        return ret
     }
 }
 

--- a/cargo-fix/tests/all/smoke.rs
+++ b/cargo-fix/tests/all/smoke.rs
@@ -100,3 +100,31 @@ fn preserve_line_endings() {
     p.expect_cmd("cargo fix").run();
     assert!(p.read("src/lib.rs").contains("\r\n"));
 }
+
+#[test]
+fn multiple_suggestions_for_the_same_thing() {
+    let p = project()
+        .file("src/lib.rs", "\
+            fn main() {
+                let xs = vec![String::from(\"foo\")];
+                // error: no diplay in scope, and there are two options
+                // (std::path::Display and std::fmt::Display)
+                let d: &Display = &xs;
+                println!(\"{}\", d);
+            }
+        ")
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 (CWD)
+error: Cannot replace slice of data that was already replaced
+error: Could not compile `foo`.
+
+To learn more, run the command again with --verbose.
+";
+
+    p.expect_cmd("cargo fix")
+        .stderr(stderr)
+        .status(101)
+        .run();
+}

--- a/cargo-fix/tests/all/smoke.rs
+++ b/cargo-fix/tests/all/smoke.rs
@@ -87,3 +87,16 @@ fn tricky_ampersand() {
         .stderr(stderr)
         .run();
 }
+
+#[test]
+fn preserve_line_endings() {
+    let p = project()
+        .file("src/lib.rs", "\
+            fn add(a: &u32) -> u32 { a + 1 }\r\n\
+            pub fn foo() -> u32 { add(1) }\r\n\
+        ")
+        .build();
+
+    p.expect_cmd("cargo fix").run();
+    assert!(p.read("src/lib.rs").contains("\r\n"));
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,5 +1,5 @@
 //! Rustc Diagnostic JSON Output
-//! 
+//!
 //! The following data types are copied from [rust-lang/rust](https://github.com/rust-lang/rust/blob/de78655bca47cac8e783dbb563e7e5c25c1fae40/src/libsyntax/json.rs)
 
 #[derive(Deserialize, Debug)]
@@ -21,8 +21,8 @@ pub struct Diagnostic {
 #[derive(Deserialize, Debug)]
 pub struct DiagnosticSpan {
     pub file_name: String,
-    byte_start: u32,
-    byte_end: u32,
+    pub byte_start: u32,
+    pub byte_end: u32,
     /// 1-based.
     pub line_start: usize,
     pub line_end: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+#[macro_use]
 extern crate failure;
-extern crate replace_rs as replace;
+#[cfg(test)]
+#[macro_use]
+extern crate proptest;
 
 use std::collections::HashSet;
 use std::ops::Range;
@@ -11,6 +14,7 @@ use failure::Error;
 
 pub mod diagnostics;
 use diagnostics::{Diagnostic, DiagnosticSpan};
+mod replace;
 
 pub fn get_suggestions_from_json<S: ::std::hash::BuildHasher>(
     input: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ pub fn apply_suggestions(code: &str, suggestions: &[Suggestion]) -> Result<Strin
             for r in &sol.replacements {
                 fixed.replace_range(
                     r.snippet.range.start,
-                    r.snippet.range.end - 1,
+                    r.snippet.range.end.saturating_sub(1),
                     r.replacement.as_bytes(),
                 )?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,48 +177,6 @@ pub fn collect_suggestions<S: ::std::hash::BuildHasher>(diagnostic: &Diagnostic,
     }
 }
 
-pub fn apply_suggestion(file_content: &mut String, suggestion: &Replacement) -> String {
-    use std::cmp::max;
-
-    let mut new_content = String::new();
-
-    // Add the lines before the section we want to replace
-    new_content.push_str(&file_content.lines()
-        .take(max(suggestion.snippet.line_range.start.line - 1, 0) as usize)
-        .collect::<Vec<_>>()
-        .join("\n"));
-    new_content.push_str("\n");
-
-    // Parts of line before replacement
-    new_content.push_str(&file_content.lines()
-        .nth(suggestion.snippet.line_range.start.line - 1)
-        .unwrap_or("")
-        .chars()
-        .take(suggestion.snippet.line_range.start.column - 1)
-        .collect::<String>());
-
-    // Insert new content! Finally!
-    new_content.push_str(&suggestion.replacement);
-
-    // Parts of line after replacement
-    new_content.push_str(&file_content.lines()
-        .nth(suggestion.snippet.line_range.end.line - 1)
-        .unwrap_or("")
-        .chars()
-        .skip(suggestion.snippet.line_range.end.column - 1)
-        .collect::<String>());
-
-    // Add the lines after the section we want to replace
-    new_content.push_str("\n");
-    new_content.push_str(&file_content.lines()
-        .skip(suggestion.snippet.line_range.end.line as usize)
-        .collect::<Vec<_>>()
-        .join("\n"));
-    new_content.push_str("\n");
-
-    new_content
-}
-
 pub fn apply_suggestions(code: &str, suggestions: &[Suggestion]) -> Result<String, Error> {
     use replace::Data;
 

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,0 +1,223 @@
+//! A small module giving you a simple container that allows easy and cheap
+//! replacement of parts of its content, with the ability to prevent changing
+//! the same parts multiple times.
+
+use std::rc::Rc;
+use failure::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum State {
+    Initial,
+    Replaced(Rc<[u8]>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Span {
+    /// Start of this span in parent data
+    start: usize,
+    /// up to end inculding
+    end: usize,
+    data: State,
+}
+
+/// A container that allows easily replacing chunks of its data
+#[derive(Debug, Clone, Default)]
+pub struct Data {
+    original: Vec<u8>,
+    parts: Vec<Span>,
+}
+
+impl Data {
+    /// Create a new data container from a slice of bytes
+    pub fn new(data: &[u8]) -> Self {
+        Data {
+            original: data.into(),
+            parts: vec![Span {
+                data: State::Initial,
+                start: 0,
+                end: data.len(),
+            }],
+        }
+    }
+
+    /// Render this data as a vector of bytes
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.parts.iter().fold(Vec::new(), |mut acc, d| {
+            match d.data {
+                State::Initial => acc.extend_from_slice(&self.original[d.start..d.end]),
+                State::Replaced(ref d) => acc.extend_from_slice(&d),
+            };
+            acc
+        })
+    }
+
+    /// Replace a chunk of data with the given slice, erroring when this part
+    /// was already changed previously.
+    pub fn replace_range(
+        &mut self,
+        from: usize,
+        up_to_and_including: usize,
+        data: &[u8],
+    ) -> Result<(), Error> {
+        ensure!(
+            from <= up_to_and_including,
+            "Invalid range {}...{}, start is larger than end",
+            from,
+            up_to_and_including
+        );
+        ensure!(
+            up_to_and_including <= self.original.len(),
+            "Invalid range {}...{} given, original data is only {} byte long",
+            from,
+            up_to_and_including,
+            self.original.len()
+        );
+
+        // Since we error out when replacing an already replaced chunk of data,
+        // we can take some shortcuts here. For example, there can be no
+        // overlapping replacements -- we _always_ split a chunk of 'initial'
+        // data into three[^empty] parts, and there can't ever be two 'initial'
+        // parts touching.
+        //
+        // [^empty]: Leading and trailing ones might be empty if we replace
+        // the whole chunk. As an optimization and without loss of generality we
+        // don't add empty parts.
+        let new_parts = {
+            let index_of_part_to_split = self.parts
+                .iter()
+                .position(|p| p.start <= from && p.end >= up_to_and_including)
+                .ok_or_else(|| {
+                    format_err!(
+                        "Could not find data slice that covers range {}..{}",
+                        from,
+                        up_to_and_including
+                    )
+                })?;
+
+            let part_to_split = &self.parts[index_of_part_to_split];
+            ensure!(
+                part_to_split.data == State::Initial,
+                "Cannot replace slice of data that was already replaced"
+            );
+
+            let mut new_parts = Vec::with_capacity(self.parts.len() + 2);
+
+            // Previous parts
+            if let Some(ps) = self.parts.get(..index_of_part_to_split) {
+                new_parts.extend_from_slice(&ps);
+            }
+
+            // Keep initial data on left side of part
+            if from > part_to_split.start {
+                new_parts.push(Span {
+                    start: part_to_split.start,
+                    end: from,
+                    data: State::Initial,
+                });
+            }
+
+            // New part
+            new_parts.push(Span {
+                start: from,
+                end: up_to_and_including,
+                data: State::Replaced(data.into()),
+            });
+
+            // Keep initial data on right side of part
+            if up_to_and_including < part_to_split.end {
+                new_parts.push(Span {
+                    start: up_to_and_including + 1,
+                    end: part_to_split.end,
+                    data: State::Initial,
+                });
+            }
+
+            // Following parts
+            if let Some(ps) = self.parts.get(index_of_part_to_split + 1..) {
+                new_parts.extend_from_slice(&ps);
+            }
+
+            new_parts
+        };
+
+        self.parts = new_parts;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn str(i: &[u8]) -> &str {
+        ::std::str::from_utf8(i).unwrap()
+    }
+
+    #[test]
+    fn replace_some_stuff() {
+        let mut d = Data::new(b"foo bar baz");
+        d.replace_range(4, 6, b"lol").unwrap();
+        assert_eq!("foo lol baz", str(&d.to_vec()));
+    }
+
+    #[test]
+    fn replace_a_single_char() {
+        let mut d = Data::new(b"let y = true;");
+        d.replace_range(4, 4, b"mut y").unwrap();
+        assert_eq!("let mut y = true;", str(&d.to_vec()));
+    }
+
+    #[test]
+    fn replace_multiple_lines() {
+        let mut d = Data::new(b"lorem\nipsum\ndolor");
+
+        d.replace_range(6, 10, b"lol").unwrap();
+        assert_eq!("lorem\nlol\ndolor", str(&d.to_vec()));
+
+        d.replace_range(12, 17, b"lol").unwrap();
+        assert_eq!("lorem\nlol\nlol", str(&d.to_vec()));
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot replace slice of data that was already replaced")]
+    fn replace_overlapping_stuff_errs() {
+        let mut d = Data::new(b"foo bar baz");
+
+        d.replace_range(4, 6, b"lol").unwrap();
+        assert_eq!("foo lol baz", str(&d.to_vec()));
+
+        d.replace_range(4, 6, b"lol").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "original data is only 3 byte long")]
+    fn broken_replacements() {
+        let mut d = Data::new(b"foo");
+        d.replace_range(4, 7, b"lol").unwrap();
+    }
+
+    proptest! {
+        #[test]
+        #[ignore]
+        fn new_to_vec_roundtrip(ref s in "\\PC*") {
+            assert_eq!(s.as_bytes(), Data::new(s.as_bytes()).to_vec().as_slice());
+        }
+
+        #[test]
+        #[ignore]
+        fn replace_random_chunks(
+            ref data in "\\PC*",
+            ref replacements in prop::collection::vec(
+                (any::<::std::ops::Range<usize>>(), any::<Vec<u8>>()),
+                1..1337,
+            )
+        ) {
+            let mut d = Data::new(data.as_bytes());
+            for &(ref range, ref bytes) in replacements {
+                let _ = d.replace_range(range.start, range.end, bytes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #57

Btw, this is still only concerning itself with replacing multiple things in one file. #66 changes the CLI to group suggestions by file. Not sure if we want to make this part of the library.
