### PR TITLE
Cargo fix output

### DIFF
--- a/cargo-fix/Cargo.toml
+++ b/cargo-fix/Cargo.toml
@@ -21,6 +21,8 @@ env_logger = { version = "0.5", default-features = false }
 clap = "2.31"
 termcolor = "0.3.6"
 atty = "0.2.10"
+serde_derive = "1.0.45"
+serde = "1.0.45"
 
 [dev-dependencies]
 difference = "2"

--- a/cargo-fix/Cargo.toml
+++ b/cargo-fix/Cargo.toml
@@ -19,6 +19,8 @@ serde_json = "1"
 log = "0.4"
 env_logger = { version = "0.5", default-features = false }
 clap = "2.31"
+termcolor = "0.3.6"
+atty = "0.2.10"
 
 [dev-dependencies]
 difference = "2"

--- a/cargo-fix/src/diagnostics.rs
+++ b/cargo-fix/src/diagnostics.rs
@@ -1,0 +1,87 @@
+//! A small TCP server to handle collection of diagnostics information in a
+//! cross-platform way.
+
+use std::env;
+use std::io::BufReader;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::thread::{self, JoinHandle};
+
+use failure::{Error, ResultExt};
+use serde_json;
+
+static DIAGNOSICS_SERVER_VAR: &str = "__CARGO_FIX_DIAGNOSTICS_SERVER";
+
+#[derive(Deserialize, Serialize)]
+pub enum Message {
+    Fixing { file: String, fixes: usize },
+}
+
+impl Message {
+    pub fn fixing(file: &str, num: usize) -> Message {
+        Message::Fixing {
+            file: file.into(),
+            fixes: num,
+        }
+    }
+
+    pub fn post(&self) -> Result<(), Error> {
+        let addr = env::var(DIAGNOSICS_SERVER_VAR).context("diagnostics collector misconfigured")?;
+        let mut client =
+            TcpStream::connect(&addr).context("failed to connect to parent diagnostics target")?;
+
+        serde_json::to_writer(&mut client, &self)
+            .context("failed to write message to diagnostics target")?;
+
+        Ok(())
+    }
+}
+
+pub struct Server {
+    listener: TcpListener,
+}
+
+pub struct StartedServer {
+    _addr: SocketAddr,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Server {
+    pub fn new() -> Result<Self, Error> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .with_context(|_| "failed to bind TCP listener to manage locking")?;
+        env::set_var(DIAGNOSICS_SERVER_VAR, listener.local_addr()?.to_string());
+
+        Ok(Server { listener })
+    }
+
+    pub fn start<F: Fn(Message) + Send + 'static>(
+        self,
+        on_message: F,
+    ) -> Result<StartedServer, Error> {
+        let _addr = self.listener.local_addr()?;
+        let thread = thread::spawn(move || {
+            self.run(on_message);
+        });
+
+        Ok(StartedServer {
+            _addr,
+            thread: Some(thread),
+        })
+    }
+
+    fn run<F: Fn(Message)>(self, on_message: F) {
+        while let Ok((client, _)) = self.listener.accept() {
+            let mut client = BufReader::new(client);
+            match serde_json::from_reader(client) {
+                Ok(message) => on_message(message),
+                Err(e) => { warn!("invalid diagnostics message: {}", e); }
+            }
+        }
+    }
+}
+
+impl Drop for StartedServer {
+    fn drop(&mut self) {
+        drop(self.thread.take().unwrap().join());
+    }
+}

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -4,6 +4,8 @@ extern crate failure;
 extern crate rustfix;
 extern crate serde_json;
 #[macro_use]
+extern crate serde_derive;
+#[macro_use]
 extern crate log;
 extern crate env_logger;
 extern crate atty;
@@ -22,6 +24,7 @@ use failure::{Error, ResultExt};
 
 mod cli;
 mod lock;
+mod diagnostics;
 
 fn main() {
     env_logger::init();
@@ -195,10 +198,8 @@ fn rustfix_crate(rustc: &Path, filename: &str) -> Result<HashMap<String, String>
         }
         let num_suggestions = suggestions.len();
         debug!("applying {} fixes to {}", num_suggestions, file);
-        log_for_human("Fixing", &format!("{name} ({n} {fixes})",
-            name = file, n = num_suggestions,
-            fixes = if num_suggestions > 1 { "fixes" } else { "fix" },
-        ))?;
+
+        diagnostics::Message::fixing(&file, num_suggestion).post()?;
 
         let new_code = rustfix::apply_suggestions(&code, &suggestions)?;
         File::create(&file)
@@ -208,30 +209,6 @@ fn rustfix_crate(rustc: &Path, filename: &str) -> Result<HashMap<String, String>
     }
 
     Ok(old_files)
-}
-
-fn log_for_human(kind: &str, msg: &str) -> Result<(), Error> {
-    use std::io::Write;
-    use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
-
-    // Adapted from cargo, cf. <https://github.com/rust-lang/cargo/blob/5986492773e6de61cced57f457da3700607f4a3a/src/cargo/core/shell.rs#L291>
-    let color_choice = if atty::is(atty::Stream::Stderr) {
-        ColorChoice::Auto
-    } else {
-        ColorChoice::Never
-    };
-    let mut stream = StandardStream::stderr(color_choice);
-    stream.reset()?;
-
-    stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Green)))?;
-    // Justify to 12 chars just like cargo
-    write!(&mut stream, "{:>12}", kind)?;
-    stream.reset()?;
-
-    write!(&mut stream, " {}\n", msg)?;
-    stream.flush()?;
-
-    Ok(())
 }
 
 fn exit_with(status: ExitStatus) -> ! {

--- a/cargo-fix/tests/all/dependencies.rs
+++ b/cargo-fix/tests/all/dependencies.rs
@@ -42,7 +42,9 @@ fn fix_path_deps() {
 
     let stderr = "\
 [CHECKING] bar v0.1.0 (CWD/bar)
+[FIXING] bar/src/lib.rs (1 fix)
 [CHECKING] foo v0.1.0 (CWD)
+[FIXING] src/lib.rs (1 fix)
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -218,9 +218,11 @@ impl<'a> ExpectCmd<'a> {
 
     fn clean(&self, s: &str) -> String {
         let url = Url::from_file_path(&self.project.root).unwrap();
-        let s = s.replace("[CHECKING]", "    Checking")
-            .replace("[FINISHED]", "    Finished")
+        let s = s
+            .replace("[CHECKING]",  "    Checking")
+            .replace("[FINISHED]",  "    Finished")
             .replace("[COMPILING]", "   Compiling")
+            .replace("[FIXING]",    "      Fixing")
             .replace(&url.to_string(), "CWD")
             .replace(&self.project.root.display().to_string(), "CWD")
             .replace("\\", "/");

--- a/cargo-fix/tests/all/smoke.rs
+++ b/cargo-fix/tests/all/smoke.rs
@@ -29,6 +29,7 @@ fn fixes_extra_mut() {
 
     let stderr = "\
 [CHECKING] foo v0.1.0 (CWD)
+[FIXING] src/lib.rs (1 fix)
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
@@ -51,6 +52,7 @@ fn fixes_two_missing_ampersands() {
 
     let stderr = "\
 [CHECKING] foo v0.1.0 (CWD)
+[FIXING] src/lib.rs (2 fixes)
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
@@ -72,6 +74,7 @@ fn tricky() {
 
     let stderr = "\
 [CHECKING] foo v0.1.0 (CWD)
+[FIXING] src/lib.rs (2 fixes)
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")

--- a/cargo-fix/tests/all/subtargets.rs
+++ b/cargo-fix/tests/all/subtargets.rs
@@ -24,11 +24,21 @@ fn fixes_missing_ampersand() {
         "#)
         .build();
 
-    let stderr = "\
-[COMPILING] foo v0.1.0 (CWD)
-[FINISHED] dev [unoptimized + debuginfo]
-";
-    p.expect_cmd("cargo fix -- --all-targets").stdout("").stderr(stderr).run();
+    p.expect_cmd("cargo fix -- --all-targets")
+        .stdout("")
+        .stderr_contains("[COMPILING] foo v0.1.0 (CWD)")
+        .stderr_contains("[FIXING] build.rs (1 fix)")
+        // Don't assert number of fixes for this one, as we don't know if we're
+        // fixing it once or twice! We run this all concurrently, and if we
+        // compile (and fix) in `--test` mode first, we get two fixes. Otherwise
+        // we'll fix one non-test thing, and then fix another one later in
+        // test mode.
+        .stderr_contains("[FIXING] src/lib.rs")
+        .stderr_contains("[FIXING] src/main.rs (1 fix)")
+        .stderr_contains("[FIXING] examples/foo.rs (1 fix)")
+        .stderr_contains("[FIXING] tests/a.rs (1 fix)")
+        .stderr_contains("[FINISHED] dev [unoptimized + debuginfo]")
+        .run();
     p.expect_cmd("cargo build").run();
     p.expect_cmd("cargo test").run();
 }


### PR DESCRIPTION
Currently, running `cargo fix` ends up printing a bunch of "Checking …"
lines from the internal `cargo check` calls. In the step where we apply
suggestions, I've now added "Fixing …" lines -- one per file. The style
is the same as cargo's (it's using the same crates and color detection).

based on #82 
concerns #76