### PR TITLE
Start giving `cargo fix` a dedicated CLI

### DIFF
--- a/cargo-fix/Cargo.toml
+++ b/cargo-fix/Cargo.toml
@@ -18,6 +18,7 @@ rustfix = { path = "..", version = "0.2" }
 serde_json = "1"
 log = "0.4"
 env_logger = { version = "0.5", default-features = false }
+clap = "2.31"
 
 [dev-dependencies]
 difference = "2"

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -1,0 +1,71 @@
+use std::env;
+use std::process::Command;
+
+use failure::{Error, ResultExt};
+use clap::{Arg, App, SubCommand, AppSettings};
+
+use lock::Server;
+use super::exit_with;
+
+pub fn run() -> Result<(), Error> {
+    let matches = App::new("Cargo Fix")
+        .bin_name("cargo")
+        .subcommand(
+            SubCommand::with_name("fix")
+                .version(env!("CARGO_PKG_VERSION"))
+                .author("The Rust Project Developers")
+                .about("Automatically apply rustc's suggestions about fixing code")
+                .setting(AppSettings::TrailingVarArg)
+                .arg(Arg::with_name("args").multiple(true))
+                .arg(
+                    Arg::with_name("broken-code")
+                        .long("broken-code")
+                        .help("Fix code even if it already has compiler errors")
+                )
+        )
+        .get_matches();
+    let matches = match matches.subcommand() {
+        ("fix", Some(matches)) => matches,
+        _ => bail!("unknown cli arguments passed"),
+    };
+
+    if matches.is_present("broken-code") {
+        env::set_var("__CARGO_FIX_BROKEN_CODE", "1");
+    }
+
+    // Spin up our lock server which our subprocesses will use to synchronize
+    // fixes.
+    let _lockserver = Server::new()?.start()?;
+
+    let cargo = env::var_os("CARGO").unwrap_or("cargo".into());
+    let mut cmd = Command::new(&cargo);
+    // TODO: shouldn't hardcode `check` here, we want to allow things like
+    // `cargo fix bench` or something like that
+    //
+    // TODO: somehow we need to force `check` to actually do something here, if
+    // `cargo check` was previously run it won't actually do anything again.
+    cmd.arg("check");
+    if let Some(args) = matches.values_of("args") {
+        cmd.args(args);
+    }
+
+    // Override the rustc compiler as ourselves. That way whenever rustc would
+    // run we run instead and have an opportunity to inject fixes.
+    let me = env::current_exe()
+        .context("failed to learn about path to current exe")?;
+    cmd.env("RUSTC", &me)
+        .env("__CARGO_FIX_NOW_RUSTC", "1");
+    if let Some(rustc) = env::var_os("RUSTC") {
+        cmd.env("RUSTC_ORIGINAL", rustc);
+    }
+
+    // An now execute all of Cargo! This'll fix everything along the way.
+    //
+    // TODO: we probably want to do something fancy here like collect results
+    // from the client processes and print out a summary of what happened.
+    let status = cmd.status()
+        .with_context(|e| {
+            format!("failed to execute `{}`: {}", cargo.to_string_lossy(), e)
+        })?;
+    exit_with(status);
+}

--- a/cargo-fix/tests/all/broken_build.rs
+++ b/cargo-fix/tests/all/broken_build.rs
@@ -25,6 +25,25 @@ fn do_not_fix_broken_builds() {
 }
 
 #[test]
+fn fix_broken_if_requested() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+                fn foo(a: &u32) -> u32 { a + 1 }
+                pub fn bar() {
+                    foo(1);
+                }
+            "#
+        )
+        .build();
+
+    p.expect_cmd("cargo-fix fix --broken-code")
+        .status(0)
+        .run();
+}
+
+#[test]
 fn broken_fixes_backed_out() {
     let p = project()
         .file(

--- a/cargo-fix/tests/all/subtargets.rs
+++ b/cargo-fix/tests/all/subtargets.rs
@@ -28,7 +28,7 @@ fn fixes_missing_ampersand() {
 [COMPILING] foo v0.1.0 (CWD)
 [FINISHED] dev [unoptimized + debuginfo]
 ";
-    p.expect_cmd("cargo fix --all-targets").stdout("").stderr(stderr).run();
+    p.expect_cmd("cargo fix -- --all-targets").stdout("").stderr(stderr).run();
     p.expect_cmd("cargo build").run();
     p.expect_cmd("cargo test").run();
 }
@@ -57,6 +57,6 @@ fn fix_features() {
 
     p.expect_cmd("cargo fix").run();
     p.expect_cmd("cargo build").run();
-    p.expect_cmd("cargo fix --features bar").run();
+    p.expect_cmd("cargo fix -- --features bar").run();
     p.expect_cmd("cargo build --features bar").run();
 }


### PR DESCRIPTION
This commit pulls in `clap` to have a location to actually insert a CLI for
`cargo fix` itself. This'll hopefully allow us to continue to configure
cargo-fix's behavior while also allowing passing arguments down to Cargo.

This starts out by adding a `--broken-code` option which can be used to specify
that previously broken code should be fixed, despite it being originally
broken.

Closes #70
Closes #71
Closes #84