### PR TITLE
Switch "fixing" messages to Cyan

### DIFF
--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -107,7 +107,7 @@ fn log_for_human(kind: &str, msg: &str) -> Result<(), Error> {
     let mut stream = StandardStream::stderr(color_choice);
     stream.reset()?;
 
-    stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Green)))?;
+    stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Cyan)))?;
     // Justify to 12 chars just like cargo
     write!(&mut stream, "{:>12}", kind)?;
     stream.reset()?;


### PR DESCRIPTION
This is hopefully a little easier to see in contrast to the normal green
"Compiling", and it stood out a bit more for me locally