### PR TITLE
Don't print "Fixing" if fixes are reverted

### DIFF
--- a/cargo-fix/tests/all/broken_build.rs
+++ b/cargo-fix/tests/all/broken_build.rs
@@ -110,6 +110,7 @@ fn broken_fixes_backed_out() {
         .cwd("bar")
         .env("RUSTC", p.root.join("foo/target/debug/foo"))
         .stderr_contains("oh no")
+        .stderr_not_contains("[FIXING]")
         .status(101)
         .run();
 


### PR DESCRIPTION
This commit alters the printing of `Fixing` to not happen if we end up
reverting the fixes that we applied. Instead the message of `Fixing` is delayed
until *after* we've run through the compiler and know that we've fixed the code.

This also updates the `Message::post` method to block until the diagnostic has
finished writing, which fixes a race that was coming up in the test suite.