### PR TITLE
Filter by machine applicability

### DIFF
--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -112,8 +112,7 @@ pub fn run() -> Result<(), Error> {
     //
     // TODO: we probably want to do something fancy here like collect results
     // from the client processes and print out a summary of what happened.
-    let status = cmd
-        .status()
+    let status = cmd.status()
         .with_context(|e| format!("failed to execute `{}`: {}", cargo.to_string_lossy(), e))?;
     exit_with(status);
 }

--- a/cargo-fix/tests/all/broken_build.rs
+++ b/cargo-fix/tests/all/broken_build.rs
@@ -37,7 +37,7 @@ fn fix_broken_if_requested() {
         .build();
 
     p.expect_cmd("cargo-fix fix --broken-code")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .status(0)
         .run();
 }
@@ -114,7 +114,7 @@ fn broken_fixes_backed_out() {
 
     // Attempt to fix code, but our shim will always fail the second compile
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .cwd("bar")
         .env("RUSTC", p.root.join("foo/target/debug/foo"))
         .stderr_contains("not rust code")

--- a/cargo-fix/tests/all/broken_build.rs
+++ b/cargo-fix/tests/all/broken_build.rs
@@ -36,7 +36,10 @@ fn fix_broken_if_requested() {
         )
         .build();
 
-    p.expect_cmd("cargo-fix fix --broken-code").status(0).run();
+    p.expect_cmd("cargo-fix fix --broken-code")
+        .env("__CARGO_FIX_YOLO", "true")
+        .status(0)
+        .run();
 }
 
 #[test]
@@ -111,6 +114,7 @@ fn broken_fixes_backed_out() {
 
     // Attempt to fix code, but our shim will always fail the second compile
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .cwd("bar")
         .env("RUSTC", p.root.join("foo/target/debug/foo"))
         .stderr_contains("not rust code")

--- a/cargo-fix/tests/all/broken_lints.rs
+++ b/cargo-fix/tests/all/broken_lints.rs
@@ -19,7 +19,7 @@
 //         .build();
 
 //     p.expect_cmd("cargo-fix fix")
-//         .env("__CARGO_FIX_YOLO", "true")
+//         .fix_everything()
 //         .stderr_contains(r"warning: error applying suggestions to `src/lib.rs`")
 //         .stderr_contains("The full error message was:")
 //         .stderr_contains("> Could not replace range 56...60 in file -- maybe parts of it were already replaced?")

--- a/cargo-fix/tests/all/broken_lints.rs
+++ b/cargo-fix/tests/all/broken_lints.rs
@@ -19,21 +19,18 @@
 //         .build();
 
 //     p.expect_cmd("cargo-fix fix")
+//         .env("__CARGO_FIX_YOLO", "true")
 //         .stderr_contains(r"warning: error applying suggestions to `src/lib.rs`")
 //         .stderr_contains("The full error message was:")
-//         .stderr_contains(
-//             "> Could not replace range 56...60 in file -- maybe parts of it were already replaced?",
-//         )
-//         .stderr_contains(
-//             "\
-//              This likely indicates a bug in either rustc or rustfix itself,\n\
-//              and we would appreciate a bug report! You're likely to see \n\
-//              a number of compiler warnings after this message which rustfix\n\
-//              attempted to fix but failed. If you could open an issue at\n\
-//              https://github.com/rust-lang-nursery/rustfix/issues\n\
-//              quoting the full output of this command we'd be very appreciative!\n\n\
-//              ",
-//         )
+//         .stderr_contains("> Could not replace range 56...60 in file -- maybe parts of it were already replaced?")
+//         .stderr_contains("\
+//             This likely indicates a bug in either rustc or rustfix itself,\n\
+//             and we would appreciate a bug report! You're likely to see \n\
+//             a number of compiler warnings after this message which rustfix\n\
+//             attempted to fix but failed. If you could open an issue at\n\
+//             https://github.com/rust-lang-nursery/rustfix/issues\n\
+//             quoting the full output of this command we'd be very appreciative!\n\n\
+//         ")
 //         .status(0)
 //         .run();
 // }

--- a/cargo-fix/tests/all/dependencies.rs
+++ b/cargo-fix/tests/all/dependencies.rs
@@ -54,6 +54,7 @@ fn fix_path_deps() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();

--- a/cargo-fix/tests/all/dependencies.rs
+++ b/cargo-fix/tests/all/dependencies.rs
@@ -54,7 +54,7 @@ fn fix_path_deps() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stdout("")
         .stderr(stderr)
         .run();

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -161,7 +161,7 @@ fn upgrade_extern_crate() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stdout("")
         .stderr(stderr)
         .run();

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -72,7 +72,6 @@ fn local_paths() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix --prepare-for 2018")
-        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();
@@ -105,7 +104,6 @@ fn local_paths_no_fix() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix --prepare-for 2018")
-        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -72,6 +72,7 @@ fn local_paths() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix --prepare-for 2018")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();
@@ -104,6 +105,7 @@ fn local_paths_no_fix() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix --prepare-for 2018")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();
@@ -161,6 +163,7 @@ fn upgrade_extern_crate() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -151,6 +151,11 @@ impl<'a> ExpectCmd<'a> {
         self
     }
 
+    fn fix_everything(&mut self) -> &mut Self {
+        self.env("__CARGO_FIX_YOLO", "true");
+        self
+    }
+
     fn stdout(&mut self, s: &str) -> &mut Self {
         self.stdout = Some(s.to_string());
         self

--- a/cargo-fix/tests/all/smoke.rs
+++ b/cargo-fix/tests/all/smoke.rs
@@ -34,7 +34,7 @@ fn fixes_extra_mut() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stdout("")
         .stderr(stderr)
         .run();
@@ -61,7 +61,7 @@ fn fixes_two_missing_ampersands() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stdout("")
         .stderr(stderr)
         .run();
@@ -87,7 +87,7 @@ fn tricky() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stdout("")
         .stderr(stderr)
         .run();
@@ -106,7 +106,7 @@ fn preserve_line_endings() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .run();
     assert!(p.read("src/lib.rs").contains("\r\n"));
 }
@@ -124,7 +124,7 @@ fn fix_deny_warnings() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .run();
 }
 
@@ -147,7 +147,7 @@ fn fix_deny_warnings_but_not_others() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .run();
     assert!(!p.read("src/lib.rs").contains("let mut x = 3;"));
     assert!(p.read("src/lib.rs").contains("fn bar() {}"));
@@ -179,7 +179,7 @@ fn fix_two_files() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stderr_contains("[FIXING] src/bar.rs (1 fix)")
         .stderr_contains("[FIXING] src/lib.rs (1 fix)")
         .run();

--- a/cargo-fix/tests/all/smoke.rs
+++ b/cargo-fix/tests/all/smoke.rs
@@ -34,6 +34,7 @@ fn fixes_extra_mut() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();
@@ -60,6 +61,7 @@ fn fixes_two_missing_ampersands() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();
@@ -85,6 +87,7 @@ fn tricky() {
 [FINISHED] dev [unoptimized + debuginfo]
 ";
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr(stderr)
         .run();
@@ -102,7 +105,9 @@ fn preserve_line_endings() {
         )
         .build();
 
-    p.expect_cmd("cargo-fix fix").run();
+    p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
+        .run();
     assert!(p.read("src/lib.rs").contains("\r\n"));
 }
 
@@ -118,7 +123,9 @@ fn fix_deny_warnings() {
         )
         .build();
 
-    p.expect_cmd("cargo-fix fix").run();
+    p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
+        .run();
 }
 
 #[test]
@@ -139,7 +146,9 @@ fn fix_deny_warnings_but_not_others() {
         )
         .build();
 
-    p.expect_cmd("cargo-fix fix").run();
+    p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
+        .run();
     assert!(!p.read("src/lib.rs").contains("let mut x = 3;"));
     assert!(p.read("src/lib.rs").contains("fn bar() {}"));
 }
@@ -170,6 +179,7 @@ fn fix_two_files() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
+        .env("__CARGO_FIX_YOLO", "true")
         .stderr_contains("[FIXING] src/bar.rs (1 fix)")
         .stderr_contains("[FIXING] src/lib.rs (1 fix)")
         .run();

--- a/cargo-fix/tests/all/subtargets.rs
+++ b/cargo-fix/tests/all/subtargets.rs
@@ -40,7 +40,7 @@ fn fixes_missing_ampersand() {
         .build();
 
     p.expect_cmd("cargo fix -- --all-targets")
-        .env("__CARGO_FIX_YOLO", "true")
+        .fix_everything()
         .stdout("")
         .stderr_contains("[COMPILING] foo v0.1.0 (CWD)")
         .stderr_contains("[FIXING] build.rs (1 fix)")

--- a/cargo-fix/tests/all/subtargets.rs
+++ b/cargo-fix/tests/all/subtargets.rs
@@ -40,6 +40,7 @@ fn fixes_missing_ampersand() {
         .build();
 
     p.expect_cmd("cargo fix -- --all-targets")
+        .env("__CARGO_FIX_YOLO", "true")
         .stdout("")
         .stderr_contains("[COMPILING] foo v0.1.0 (CWD)")
         .stderr_contains("[FIXING] build.rs (1 fix)")

--- a/cargo-fix/tests/all/vcs.rs
+++ b/cargo-fix/tests/all/vcs.rs
@@ -71,5 +71,8 @@ fn does_not_warn_about_clean_working_directory() {
         .run();
     p.expect_cmd("git config user.name RustFix").run();
     p.expect_cmd("git commit -m Initial-commit").run();
-    p.expect_cmd("cargo-fix fix").check_vcs(true).status(0).run();
+    p.expect_cmd("cargo-fix fix")
+        .check_vcs(true)
+        .status(0)
+        .run();
 }

--- a/examples/fix-json.rs
+++ b/examples/fix-json.rs
@@ -15,7 +15,11 @@ fn main() -> Result<(), Error> {
     };
 
     let suggestions = fs::read_to_string(&suggestions_file)?;
-    let suggestions = rustfix::get_suggestions_from_json(&suggestions, &HashSet::new())?;
+    let suggestions = rustfix::get_suggestions_from_json(
+        &suggestions,
+        &HashSet::new(),
+        rustfix::Filter::Everything,
+    )?;
 
     let source = fs::read_to_string(&source_file)?;
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -41,8 +41,17 @@ pub struct DiagnosticSpan {
     /// load the fully rendered version from the parent `Diagnostic`,
     /// however.
     pub suggested_replacement: Option<String>,
+    pub suggestion_applicability: Option<Applicability>,
     /// Macro invocations that created the code at this span, if any.
     expansion: Option<Box<DiagnosticSpanMacroExpansion>>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize)]
+pub enum Applicability {
+    MachineApplicable,
+    HasPlaceholders,
+    MaybeIncorrect,
+    Unspecified,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,21 @@ pub mod diagnostics;
 use diagnostics::{Diagnostic, DiagnosticSpan};
 mod replace;
 
+#[derive(Debug, Clone, Copy)]
+pub enum Filter {
+    MachineApplicableOnly,
+    Everything,
+}
+
 pub fn get_suggestions_from_json<S: ::std::hash::BuildHasher>(
     input: &str,
     only: &HashSet<String, S>,
+    filter: Filter,
 ) -> serde_json::error::Result<Vec<Suggestion>> {
     let mut result = Vec::new();
     for cargo_msg in serde_json::Deserializer::from_str(input).into_iter::<Diagnostic>() {
         // One diagnostic line might have multiple suggestions
-        result.extend(collect_suggestions(&cargo_msg?, only));
+        result.extend(collect_suggestions(&cargo_msg?, only, filter));
     }
     Ok(result)
 }
@@ -142,6 +149,7 @@ fn collect_span(span: &DiagnosticSpan) -> Option<Replacement> {
 pub fn collect_suggestions<S: ::std::hash::BuildHasher>(
     diagnostic: &Diagnostic,
     only: &HashSet<String, S>,
+    filter: Filter,
 ) -> Option<Suggestion> {
     if !only.is_empty() {
         if let Some(ref code) = diagnostic.code {
@@ -165,7 +173,21 @@ pub fn collect_suggestions<S: ::std::hash::BuildHasher>(
         .children
         .iter()
         .filter_map(|child| {
-            let replacements: Vec<_> = child.spans.iter().filter_map(collect_span).collect();
+            let replacements: Vec<_> = child
+                .spans
+                .iter()
+                .filter(|span| {
+                    use Filter::*;
+                    use diagnostics::Applicability::*;
+
+                    match (filter, &span.suggestion_applicability) {
+                        (MachineApplicableOnly, Some(MachineApplicable)) => true,
+                        (MachineApplicableOnly, _) => false,
+                        (_, _) => true,
+                    }
+                })
+                .filter_map(collect_span)
+                .collect();
             if replacements.len() == 1 {
                 Some(Solution {
                     message: child.message.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub fn collect_suggestions<S: ::std::hash::BuildHasher>(
                     match (filter, &span.suggestion_applicability) {
                         (MachineApplicableOnly, Some(MachineApplicable)) => true,
                         (MachineApplicableOnly, _) => false,
-                        (_, _) => true,
+                        (Everything, _) => true,
                     }
                 })
                 .filter_map(collect_span)

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -5,6 +5,8 @@ use std::fs;
 #[test]
 fn multiple_fix_options_yield_no_suggestions() {
     let json = fs::read_to_string("./tests/edge-cases/skip-multi-option-lints.json").unwrap();
-    let expected_suggestions = rustfix::get_suggestions_from_json(&json, &HashSet::new()).unwrap();
+    let expected_suggestions =
+        rustfix::get_suggestions_from_json(&json, &HashSet::new(), rustfix::Filter::Everything)
+            .unwrap();
     assert!(expected_suggestions.is_empty());
 }


### PR DESCRIPTION
Finally -- we have a way to indicate that we trust a lint! This is currently an unstable feature in rustc and thus requires nightly.

The first lints that are currently as machine applicable land with <https://github.com/rust-lang/rust/pull/50454>, so adding tests will have to wait for a bit -- see #95.

(this is currently based on #96)