### PR TITLE
Add `--prepare-for` flag

### DIFF
--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -88,9 +88,9 @@ pub fn run() -> Result<(), Error> {
     info!("edition upgrade? {:?}", matches.value_of("edition"));
     if let Some("2018") = matches.value_of("edition") {
         info!("edition upgrade!");
-        let mut rustc_flags = env::var_os("RUSTC_FLAGS").unwrap_or_else(|| "".into());
-        rustc_flags.push("-A warnings -W rust_2018_breakage");
-        cmd.env("RUSTC_FLAGS", &rustc_flags);
+        let mut rustc_flags = env::var_os("RUSTFLAGS").unwrap_or_else(|| "".into());
+        rustc_flags.push("-W rust-2018-breakage -A unused -A nonstandard-style -A bad-style");
+        cmd.env("RUSTFLAGS", &rustc_flags);
     }
 
     // An now execute all of Cargo! This'll fix everything along the way.

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -89,7 +89,7 @@ pub fn run() -> Result<(), Error> {
     if let Some("2018") = matches.value_of("edition") {
         info!("edition upgrade!");
         let mut rustc_flags = env::var_os("RUSTFLAGS").unwrap_or_else(|| "".into());
-        rustc_flags.push("-W rust-2018-breakage -A unused -A nonstandard-style -A bad-style");
+        rustc_flags.push("-W rust-2018-breakage");
         cmd.env("RUSTFLAGS", &rustc_flags);
     }
 

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -33,6 +33,13 @@ pub fn run() -> Result<(), Error> {
                     Arg::with_name("broken-code")
                         .long("broken-code")
                         .help("Fix code even if it already has compiler errors"),
+                )
+                .arg(
+                    Arg::with_name("edition")
+                        .long("prepare-for")
+                        .help("Fix warnigns in preparation of an edition upgrade")
+                        .takes_value(true)
+                        .possible_values(&["2018"]),
                 ),
         )
         .get_matches();
@@ -75,6 +82,15 @@ pub fn run() -> Result<(), Error> {
     cmd.env("RUSTC", &me).env("__CARGO_FIX_NOW_RUSTC", "1");
     if let Some(rustc) = env::var_os("RUSTC") {
         cmd.env("RUSTC_ORIGINAL", rustc);
+    }
+
+    // Trigger edition-upgrade mode. Currently only supports the 2018 edition.
+    info!("edition upgrade? {:?}", matches.value_of("edition"));
+    if let Some("2018") = matches.value_of("edition") {
+        info!("edition upgrade!");
+        let mut rustc_flags = env::var_os("RUSTC_FLAGS").unwrap_or_else(|| "".into());
+        rustc_flags.push("-A warnings -W rust_2018_breakage");
+        cmd.env("RUSTC_FLAGS", &rustc_flags);
     }
 
     // An now execute all of Cargo! This'll fix everything along the way.

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -37,7 +37,7 @@ pub fn run() -> Result<(), Error> {
                 .arg(
                     Arg::with_name("edition")
                         .long("prepare-for")
-                        .help("Fix warnigns in preparation of an edition upgrade")
+                        .help("Fix warnings in preparation of an edition upgrade")
                         .takes_value(true)
                         .possible_values(&["2018"]),
                 ),

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -12,7 +12,7 @@ fn prepare_for_2018() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(crate_in_paths)]
+                #![feature(rust_2018_preview )]
 
                 mod foo {
                     pub const FOO: &str = "fooo";

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -12,7 +12,6 @@ fn prepare_for_2018() {
         .file(
             "src/lib.rs",
             r#"
-                #![allow(unused)]
                 #![feature(crate_in_paths)]
 
                 mod foo {

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -1,0 +1,47 @@
+//! Test that we can use cargo-fix to upgrade our code to work with the 2018
+//! edition.
+//!
+//! We'll trigger the `absolute_path_starting_with_module` lint which should
+//! transform a `use ::foo;` where `foo` is local to `use crate::foo;`.
+
+use super::project;
+
+#[test]
+fn prepare_for_2018() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+                #![allow(unused)]
+                #![feature(crate_in_paths)]
+                #![warn(absolute_path_starting_with_module)]
+
+                mod foo {
+                    pub const FOO: &str = "fooo";
+                }
+
+                mod bar {
+                    use ::foo::FOO;
+                }
+
+                fn main() {
+                    let x = ::foo::FOO;
+                }
+            "#,
+        )
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 (CWD)
+[FIXING] src/lib.rs (2 fixes)
+[FINISHED] dev [unoptimized + debuginfo]
+";
+    p.expect_cmd("cargo-fix fix --prepare-for 2018")
+        .stdout("")
+        .stderr(stderr)
+        .run();
+
+    println!("{}", p.read("src/lib.rs"));
+    assert!(p.read("src/lib.rs").contains("use crate::foo::FOO;"));
+    assert!(p.read("src/lib.rs").contains("let x = crate::foo::FOO;"));
+}

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -14,7 +14,6 @@ fn prepare_for_2018() {
             r#"
                 #![allow(unused)]
                 #![feature(crate_in_paths)]
-                #![warn(absolute_path_starting_with_module)]
 
                 mod foo {
                     pub const FOO: &str = "fooo";

--- a/cargo-fix/tests/all/edition_upgrade.rs
+++ b/cargo-fix/tests/all/edition_upgrade.rs
@@ -12,7 +12,8 @@ fn prepare_for_2018() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(rust_2018_preview )]
+                #![allow(unused)]
+                #![feature(rust_2018_preview)]
 
                 mod foo {
                     pub const FOO: &str = "fooo";

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -318,6 +318,7 @@ fn diff(expected: &str, actual: &str) {
 mod broken_build;
 mod broken_lints;
 mod dependencies;
+mod edition_upgrade;
 mod smoke;
 mod subtargets;
 mod warnings;


### PR DESCRIPTION
This requires

    #![feature(crate_in_paths)]
    #![deny(absolute_path_starting_with_module)]

on `rustc 1.27.0-nightly (8ff4b4206 2018-05-08)`, so we're not really there yet.