### PR TITLE
Add a simple tool that applies fixes from JSON

### DIFF
--- a/examples/fix-json.rs
+++ b/examples/fix-json.rs
@@ -1,0 +1,27 @@
+extern crate failure;
+extern crate rustfix;
+
+use std::{env, fs, process, collections::HashSet};
+use failure::Error;
+
+fn main() -> Result<(), Error> {
+    let args: Vec<String> = env::args().collect();
+    let (suggestions_file, source_file) = match args.as_slice() {
+        [_, suggestions_file, source_file] => (suggestions_file, source_file),
+        _ => {
+            println!("USAGE: fix-json <suggestions-file> <source-file>");
+            process::exit(1);
+        }
+    };
+
+    let suggestions = fs::read_to_string(&suggestions_file)?;
+    let suggestions = rustfix::get_suggestions_from_json(&suggestions, &HashSet::new())?;
+
+    let source = fs::read_to_string(&source_file)?;
+
+    let fixes = rustfix::apply_suggestions(&source, &suggestions)?;
+
+    println!("{}", fixes);
+
+    Ok(())
+}


### PR DESCRIPTION
Useful when you can get rustc to emit JSON but don't want to/can't use `cargo fix` directly. Currently only supports a single source file but it's easy to extend.

cc #100