### PR TITLE
Add warning for "no VSC" and "dirty working dir"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,7 @@ install:
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V
+  - del rustup-init.exe
 
 build: false
 

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -46,7 +46,7 @@ pub fn run() -> Result<(), Error> {
                 .arg(
                     Arg::with_name("allow-no-vcs")
                         .long("allow-no-vcs")
-                        .help("Fix code even if a vcs was not detected"),
+                        .help("Fix code even if a VCS was not detected"),
                 )
                 .arg(
                     Arg::with_name("allow-dirty")
@@ -57,7 +57,7 @@ pub fn run() -> Result<(), Error> {
         .get_matches();
     let matches = match matches.subcommand() {
         ("fix", Some(matches)) => matches,
-        _ => bail!("unknown cli arguments passed"),
+        _ => bail!("unknown CLI arguments passed"),
     };
 
     if matches.is_present("broken-code") {

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -4,10 +4,10 @@ use std::process::{self, Command};
 
 use clap::{App, AppSettings, Arg, SubCommand};
 use failure::{Error, ResultExt};
-use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
+use termcolor::{ColorSpec, StandardStream, WriteColor};
 
 use super::exit_with;
-use diagnostics::{Message, Server};
+use diagnostics::{self, log_for_human, output_stream, write_warning, Message};
 use lock;
 use vcs::VersionControl;
 
@@ -152,11 +152,9 @@ fn log_message(msg: &Message, stream: &mut StandardStream) -> Result<(), Error> 
             ref file,
             ref message,
         } => {
-            stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)))?;
-            write!(stream, "warning")?;
-            stream.reset()?;
+            write_warning(stream)?;
             stream.set_color(ColorSpec::new().set_bold(true))?;
-            write!(stream, ": error applying suggestions to `{}`\n", file)?;
+            write!(stream, "error applying suggestions to `{}`\n", file)?;
             stream.reset()?;
             write!(stream, "The full error message was:\n\n> {}\n\n", message)?;
             stream.write(PLEASE_REPORT_THIS_BUG.as_bytes())?;
@@ -165,11 +163,8 @@ fn log_message(msg: &Message, stream: &mut StandardStream) -> Result<(), Error> 
             ref files,
             ref krate,
         } => {
-            stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Yellow)))?;
-            write!(stream, "warning")?;
-            stream.reset()?;
+            write_warning(stream)?;
             stream.set_color(ColorSpec::new().set_bold(true))?;
-            write!(stream, ": ")?;
             if let Some(ref krate) = *krate {
                 write!(
                     stream,
@@ -200,14 +195,5 @@ fn log_message(msg: &Message, stream: &mut StandardStream) -> Result<(), Error> 
 
     stream.reset()?;
     stream.flush()?;
-    Ok(())
-}
-
-fn log_for_human(kind: &str, msg: &str, stream: &mut StandardStream) -> Result<(), Error> {
-    stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Cyan)))?;
-    // Justify to 12 chars just like cargo
-    write!(stream, "{:>12}", kind)?;
-    stream.reset()?;
-    write!(stream, " {}\n", msg)?;
     Ok(())
 }

--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -66,12 +66,16 @@ pub fn run() -> Result<(), Error> {
 
     let version_control = VersionControl::new();
     if !version_control.is_present() && !matches.is_present("allow-no-vcs") {
-        eprintln!("no vcs found, aborting. overwrite this behavior with --allow-no-vcs");
+        eprintln!("no VCS found, aborting. overwrite this behavior with --allow-no-vcs");
         process::exit(1);
     }
 
-    if version_control.is_present() && version_control.is_dirty()? && !matches.is_present("allow-dirty") {
-        eprintln!("working directory is dirty, aborting. overwrite this behavior with --allow-dirty");
+    if version_control.is_present() && version_control.is_dirty()?
+        && !matches.is_present("allow-dirty")
+    {
+        eprintln!(
+            "working directory is dirty, aborting. overwrite this behavior with --allow-dirty"
+        );
         process::exit(1);
     }
 

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -21,8 +21,9 @@ use std::str;
 
 use failure::{Error, ResultExt};
 use rustfix::diagnostics::Diagnostic;
+use termcolor::{ColorSpec, WriteColor, Color};
 
-use diagnostics::Message;
+use diagnostics::{Message, output_stream};
 
 mod cli;
 mod diagnostics;
@@ -42,7 +43,14 @@ fn main() {
         Ok(()) => return,
         Err(e) => e,
     };
-    eprintln!("error: {}", err);
+
+    let stream = &mut output_stream();
+    let _ = stream.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Red)));
+    write!(stream, "error").unwrap();
+    let _ = stream.reset();
+    let _ = stream.set_color(ColorSpec::new().set_bold(true));
+    writeln!(stream, ": {}", err).unwrap();
+
     for cause in err.causes().skip(1) {
         eprintln!("\tcaused by: {}", cause);
     }

--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -27,6 +27,7 @@ use diagnostics::Message;
 mod cli;
 mod diagnostics;
 mod lock;
+mod vcs;
 
 fn main() {
     env_logger::init();

--- a/cargo-fix/src/vcs.rs
+++ b/cargo-fix/src/vcs.rs
@@ -1,0 +1,48 @@
+use failure::{err_msg, Error, ResultExt};
+use std::env;
+
+pub enum VersionControl {
+    Git,
+    Hg,
+    Fossil,
+    Pijul,
+    None,
+}
+
+impl VersionControl {
+    pub fn new() -> Self {
+        if is_in_vcs(".git").is_ok() {
+            VersionControl::Git
+        } else if is_in_vcs(".hg").is_ok() {
+            VersionControl::Hg
+        } else if is_in_vcs(".pijul").is_ok() {
+            VersionControl::Pijul
+        } else if is_in_vcs(".fossil").is_ok() {
+            VersionControl::Fossil
+        } else {
+            VersionControl::None
+        }
+    }
+
+    pub fn is_present(&self) -> bool {
+        match *self {
+            VersionControl::None => false,
+            _ => true,
+        }
+    }
+}
+
+fn is_in_vcs(vcs_dir: &str) -> Result<(), Error> {
+    let mut current_dir = env::current_dir().context("could not find the current directory")?;
+
+    loop {
+        if current_dir.join(vcs_dir).metadata().is_ok() {
+            return Ok(());
+        }
+
+        current_dir = current_dir
+            .parent()
+            .ok_or_else(|| err_msg("could not find the parent directory"))?
+            .to_owned();
+    }
+}

--- a/cargo-fix/src/vcs.rs
+++ b/cargo-fix/src/vcs.rs
@@ -49,7 +49,7 @@ impl VersionControl {
         let changes = String::from_utf8_lossy(&output);
         let trimmed = changes.trim();
         if !trimmed.is_empty() {
-            println!("{}", trimmed);
+            eprintln!("{}", trimmed);
         }
 
         Ok(!trimmed.is_empty())

--- a/cargo-fix/src/vcs.rs
+++ b/cargo-fix/src/vcs.rs
@@ -1,5 +1,6 @@
 use failure::{err_msg, Error, ResultExt};
 use std::env;
+use std::process::Command;
 
 pub enum VersionControl {
     Git,
@@ -29,6 +30,29 @@ impl VersionControl {
             VersionControl::None => false,
             _ => true,
         }
+    }
+
+    pub fn is_dirty(&self) -> Result<bool, Error> {
+        let (program, args) = match *self {
+            VersionControl::Git => ("git", "status --short"),
+            VersionControl::Hg => ("hg", "status"),
+            VersionControl::Pijul => ("pijul", "status"),
+            VersionControl::Fossil => ("fossil", "changes"),
+            VersionControl::None => return Ok(false),
+        };
+
+        let output = Command::new(program)
+            .args(args.split_whitespace())
+            .output()?
+            .stdout;
+
+        let changes = String::from_utf8_lossy(&output);
+        let trimmed = changes.trim();
+        if !trimmed.is_empty() {
+            println!("{}", trimmed);
+        }
+
+        Ok(!trimmed.is_empty())
     }
 }
 

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -19,6 +19,7 @@ thread_local!(static IDX: usize = CNT.fetch_add(1, Ordering::SeqCst));
 
 struct ProjectBuilder {
     files: Vec<(String, String)>,
+    root: PathBuf,
 }
 
 struct Project {
@@ -26,7 +27,10 @@ struct Project {
 }
 
 fn project() -> ProjectBuilder {
-    ProjectBuilder { files: Vec::new() }
+    ProjectBuilder {
+        files: Vec::new(),
+        root: root(),
+    }
 }
 
 fn root() -> PathBuf {
@@ -42,12 +46,20 @@ fn root() -> PathBuf {
 }
 
 impl ProjectBuilder {
-    fn file(&mut self, name: &str, contents: &str) -> &mut ProjectBuilder {
+    fn file(mut self, name: &str, contents: &str) -> ProjectBuilder {
         self.files.push((name.to_string(), contents.to_string()));
         self
     }
 
-    fn build(&mut self) -> Project {
+    fn use_temp_dir(mut self) -> ProjectBuilder {
+        let mut temp_dir = env::temp_dir();
+        temp_dir.push(&format!("rustfix-generated-test{}", IDX.with(|x| *x)));
+
+        self.root = temp_dir;
+        self
+    }
+
+    fn build(mut self) -> Project {
         if !self.files.iter().any(|f| f.0.ends_with("Cargo.toml")) {
             let manifest = r#"
                 [package]
@@ -59,17 +71,16 @@ impl ProjectBuilder {
             self.files
                 .push(("Cargo.toml".to_string(), manifest.to_string()));
         }
-        let root = root();
-        drop(fs::remove_dir_all(&root));
+        drop(fs::remove_dir_all(&self.root));
         for &(ref file, ref contents) in self.files.iter() {
-            let dst = root.join(file);
+            let dst = self.root.join(file);
             fs::create_dir_all(dst.parent().unwrap()).unwrap();
             fs::File::create(&dst)
                 .unwrap()
                 .write_all(contents.as_ref())
                 .unwrap();
         }
-        Project { root }
+        Project { root: self.root }
     }
 }
 
@@ -97,6 +108,13 @@ impl Project {
             .read_to_string(&mut ret)
             .unwrap();
         return ret;
+    }
+}
+
+impl Drop for Project {
+    fn drop(&mut self) {
+        drop(fs::remove_dir_all(&self.root));
+        drop(fs::remove_dir(&self.root));
     }
 }
 
@@ -321,4 +339,5 @@ mod dependencies;
 mod edition_upgrade;
 mod smoke;
 mod subtargets;
+mod vcs;
 mod warnings;

--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -95,6 +95,7 @@ impl Project {
             stderr: None,
             stderr_contains: Vec::new(),
             stderr_not_contains: Vec::new(),
+            check_vcs: false,
             status: 0,
             ran: false,
             cwd: None,
@@ -128,6 +129,7 @@ struct ExpectCmd<'a> {
     stderr: Option<String>,
     stderr_contains: Vec<String>,
     stderr_not_contains: Vec<String>,
+    check_vcs: bool,
     status: i32,
     cwd: Option<PathBuf>,
 }
@@ -169,6 +171,11 @@ impl<'a> ExpectCmd<'a> {
         self
     }
 
+    fn check_vcs(&mut self, b: bool) -> &mut Self {
+        self.check_vcs = b;
+        self
+    }
+
     fn run(&mut self) {
         self.ran = true;
         let mut parts = self.cmd.split_whitespace();
@@ -195,6 +202,10 @@ impl<'a> ExpectCmd<'a> {
         new_path.push(me);
         new_path.extend(env::split_paths(&env::var_os("PATH").unwrap_or(Default::default())));
         cmd.env("PATH", env::join_paths(&new_path).unwrap());
+
+        if !self.check_vcs {
+            cmd.env("__CARGO_FIX_IGNORE_VCS", "true");
+        }
 
         println!("\n···················································");
         println!("running {:?}", cmd);

--- a/cargo-fix/tests/all/vcs.rs
+++ b/cargo-fix/tests/all/vcs.rs
@@ -1,0 +1,65 @@
+use super::project;
+
+#[test]
+fn warns_if_no_vcs_detected() {
+    let p = project()
+        .use_temp_dir()
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn foo() {
+            }
+        "#,
+        )
+        .build();
+
+    p.expect_cmd("cargo-fix fix")
+        .stderr("no VCS found, aborting. overwrite this behavior with --allow-no-vcs")
+        .status(1)
+        .run();
+    p.expect_cmd("cargo-fix fix --allow-no-vcs").status(0).run();
+}
+
+#[test]
+fn warns_about_dirty_working_directory() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn foo() {
+            }
+        "#,
+        )
+        .build();
+
+    p.expect_cmd("git init").run();
+    p.expect_cmd("cargo-fix fix")
+        .stderr(
+            "?? Cargo.toml\n\
+             ?? src/\n\
+             working directory is dirty, aborting. overwrite this behavior with --allow-dirty",
+        )
+        .status(1)
+        .run();
+    p.expect_cmd("cargo-fix fix --allow-dirty").status(0).run();
+}
+
+#[test]
+fn does_not_warn_about_clean_working_directory() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn foo() {
+            }
+        "#,
+        )
+        .build();
+
+    p.expect_cmd("git init").run();
+    p.expect_cmd("git add .").run();
+    p.expect_cmd("git config user.email rustfix@rustlang.org").run();
+    p.expect_cmd("git config user.name RustFix").run();
+    p.expect_cmd("git commit -m Initial-commit").run();
+    p.expect_cmd("cargo-fix fix").status(0).run();
+}

--- a/cargo-fix/tests/all/vcs.rs
+++ b/cargo-fix/tests/all/vcs.rs
@@ -14,10 +14,13 @@ fn warns_if_no_vcs_detected() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
-        .stderr("no VCS found, aborting. overwrite this behavior with --allow-no-vcs")
-        .status(1)
+        .stderr(
+            "warning: Could not detect a version control system\n\
+             You should consider using a VCS so you can easily see and revert rustfix' changes.\n\
+             error: No VCS found, aborting. Overwrite this behavior with `--allow-no-vcs`.\n\
+             ",
+        )
         .run();
-    p.expect_cmd("cargo-fix fix --allow-no-vcs").status(0).run();
 }
 
 #[test]
@@ -35,11 +38,12 @@ fn warns_about_dirty_working_directory() {
     p.expect_cmd("git init").run();
     p.expect_cmd("cargo-fix fix")
         .stderr(
-            "?? Cargo.toml\n\
-             ?? src/\n\
-             working directory is dirty, aborting. overwrite this behavior with --allow-dirty",
+            "warning: Working directory dirty\n\
+            Make sure your working directory is clean so you can easily revert rustfix' changes.\n\
+            ?? Cargo.toml\n\
+            ?? src/\n\
+            error: Aborting because of dirty working directory. Overwrite this behavior with `--allow-dirty`.\n\n",
         )
-        .status(1)
         .run();
     p.expect_cmd("cargo-fix fix --allow-dirty").status(0).run();
 }
@@ -58,7 +62,8 @@ fn does_not_warn_about_clean_working_directory() {
 
     p.expect_cmd("git init").run();
     p.expect_cmd("git add .").run();
-    p.expect_cmd("git config user.email rustfix@rustlang.org").run();
+    p.expect_cmd("git config user.email rustfix@rustlang.org")
+        .run();
     p.expect_cmd("git config user.name RustFix").run();
     p.expect_cmd("git commit -m Initial-commit").run();
     p.expect_cmd("cargo-fix fix").status(0).run();

--- a/cargo-fix/tests/all/vcs.rs
+++ b/cargo-fix/tests/all/vcs.rs
@@ -14,13 +14,16 @@ fn warns_if_no_vcs_detected() {
         .build();
 
     p.expect_cmd("cargo-fix fix")
+        .check_vcs(true)
         .stderr(
             "warning: Could not detect a version control system\n\
              You should consider using a VCS so you can easily see and revert rustfix' changes.\n\
              error: No VCS found, aborting. Overwrite this behavior with `--allow-no-vcs`.\n\
              ",
         )
+        .status(102)
         .run();
+    p.expect_cmd("cargo-fix fix").status(0).run();
 }
 
 #[test]
@@ -37,6 +40,7 @@ fn warns_about_dirty_working_directory() {
 
     p.expect_cmd("git init").run();
     p.expect_cmd("cargo-fix fix")
+        .check_vcs(true)
         .stderr(
             "warning: Working directory dirty\n\
             Make sure your working directory is clean so you can easily revert rustfix' changes.\n\
@@ -44,6 +48,7 @@ fn warns_about_dirty_working_directory() {
             ?? src/\n\
             error: Aborting because of dirty working directory. Overwrite this behavior with `--allow-dirty`.\n\n",
         )
+        .status(102)
         .run();
     p.expect_cmd("cargo-fix fix --allow-dirty").status(0).run();
 }
@@ -66,5 +71,5 @@ fn does_not_warn_about_clean_working_directory() {
         .run();
     p.expect_cmd("git config user.name RustFix").run();
     p.expect_cmd("git commit -m Initial-commit").run();
-    p.expect_cmd("cargo-fix fix").status(0).run();
+    p.expect_cmd("cargo-fix fix").check_vcs(true).status(0).run();
 }


### PR DESCRIPTION
This builds on @BrainMaestro's #104 and changes only the way/what we output. I've also added an "ignore VSC state" env var that the integration tests can use. See the commit message for more details.

Just like #104 (and only repeating for Github to pick it up), this:

Closes #75
Closes #74