### PR TITLE
Dont pass RUST_LOG to rustc subprocess in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ failure = "0.1.1"
 log = "0.4.1"
 
 [dev-dependencies]
-duct = "0.8.2"
+duct = "0.9"
 env_logger = "0.5.0-rc.1"
 log = "0.4.1"
 tempdir = "0.3.5"

--- a/tests/parse_and_replace.rs
+++ b/tests/parse_and_replace.rs
@@ -13,9 +13,9 @@ extern crate difference;
 
 use std::collections::HashSet;
 use std::ffi::OsString;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Output;
-use std::fs;
 
 use failure::{Error, ResultExt};
 use tempdir::TempDir;
@@ -54,6 +54,7 @@ fn compile(file: &Path, mode: &str) -> Result<Output, Error> {
 
     let res = duct::cmd("rustc", &args)
         .env("CLIPPY_DISABLE_DOCS_LINKS", "true")
+        .env_remove("RUST_LOG")
         .stdout_capture()
         .stderr_capture()
         .unchecked()


### PR DESCRIPTION
Setting RUST_LOG without filtering it causes integration tests to fail
because it changes the output of rustc. By upgrading duct to 0.9 we get
env_remove which we can use to filter out the RUST_LOG setting and not
pass it down to rustc.

feel free to ignore this one, it's not tied to any issue. I was just annoyed by the fact that I had to manually filter my RUST_LOG environment variable or else it would cause the tests to start failing. It would probably bother me less if I looked up how RUST_LOG worked and figured out how to set it for all tests, it was annoying needing to move around the filter.