### PR TITLE
Overwrite RUST_LOG env var in cargo-fix tests

### DIFF
--- a/cargo-fix/tests/all/main.rs
+++ b/cargo-fix/tests/all/main.rs
@@ -203,6 +203,9 @@ impl<'a> ExpectCmd<'a> {
         new_path.extend(env::split_paths(&env::var_os("PATH").unwrap_or(Default::default())));
         cmd.env("PATH", env::join_paths(&new_path).unwrap());
 
+        // Don't output log stuff in tests, because it breaks our std{err,out} assertions
+        cmd.env("RUST_LOG", "warn");
+
         if !self.check_vcs {
             cmd.env("__CARGO_FIX_IGNORE_VCS", "true");
         }


### PR DESCRIPTION
This prevents the std{err,out} assertions from failing because of unexpected log output.