### PR TITLE
cli: fix injection of --prepare-for flags

### DIFF
--- a/cargo-fix/src/cli.rs
+++ b/cargo-fix/src/cli.rs
@@ -104,7 +104,7 @@ pub fn run() -> Result<(), Error> {
     if let Some("2018") = matches.value_of("edition") {
         info!("edition upgrade!");
         let mut rustc_flags = env::var_os("RUSTFLAGS").unwrap_or_else(|| "".into());
-        rustc_flags.push("-W rust-2018-compatibility");
+        rustc_flags.push(" -W rust-2018-compatibility");
         cmd.env("RUSTFLAGS", &rustc_flags);
     }
 


### PR DESCRIPTION
When RUSTFLAGS was set, we would previously use "§{RUSTFLAGS}-W rust-2018-compatibility" which can cause
errorous invocations like "cargo fix .... -C target-cpu=native-W rust-2018-compatibility ...." if --prepare-for 2018 is used.
We need an extra space to separate RUSTFLAGS and "-W rust-2018-compatibility" because we want
"-C target-cpu=native -W rust-2018-compatibility".