### PR TITLE
reset terminal color/bold after emitting error

### DIFF
--- a/cargo-fix/src/main.rs
+++ b/cargo-fix/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
     let _ = stream.reset();
     let _ = stream.set_color(ColorSpec::new().set_bold(true));
     writeln!(stream, ": {}", err).unwrap();
+    let _ = stream.reset();
 
     for cause in err.causes().skip(1) {
         eprintln!("\tcaused by: {}", cause);


### PR DESCRIPTION
This resolves #113, and plausibly also #115.