### PR TITLE
use RUSTC environment var in `parse_and_replace::compile` if present

### DIFF
--- a/tests/parse_and_replace.rs
+++ b/tests/parse_and_replace.rs
@@ -13,6 +13,7 @@ extern crate difference;
 
 use std::collections::HashSet;
 use std::ffi::OsString;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Output;
@@ -51,7 +52,7 @@ fn compile(file: &Path, mode: &str) -> Result<Output, Error> {
         args.push("--edition=2018".into());
     }
 
-    let res = duct::cmd("rustc", &args)
+    let res = duct::cmd(env::var_os("RUSTC").unwrap_or("rustc".into()), &args)
         .env("CLIPPY_DISABLE_DOCS_LINKS", "true")
         .env_remove("RUST_LOG")
         .stdout_capture()


### PR DESCRIPTION
Cargo respects this environment variable (to specify the path to what
rustc binary to use), but the Rustfix test suite did not. However, this
capability is useful when developing new compiler diagnostics that one
wants Rustfix to be able to handle (this being inspired by the endeavor
that is rust-lang/rust#53013).