### PR TITLE
Change example to automatically determine filename

### DIFF
--- a/examples/fix-json.rs
+++ b/examples/fix-json.rs
@@ -31,7 +31,13 @@ fn main() -> Result<(), Error> {
 
     for (source_file, suggestions) in &files {
         let source = fs::read_to_string(source_file)?;
-        let fixes = rustfix::apply_suggestions(&source, suggestions)?;
+        let mut fix = rustfix::CodeFix::new(&source);
+        for suggestion in suggestions.iter().rev() {
+            if let Err(e) = fix.apply(suggestion) {
+                eprintln!("Failed to apply suggestion to {}: {}", source_file, e);
+            }
+        }
+        let fixes = fix.finish()?;
         fs::write(source_file, fixes)?;
     }
 

--- a/examples/fix-json.rs
+++ b/examples/fix-json.rs
@@ -2,14 +2,14 @@ extern crate failure;
 extern crate rustfix;
 
 use failure::Error;
-use std::{env, fs, process, collections::HashSet};
+use std::{collections::HashMap, collections::HashSet, env, fs, process};
 
 fn main() -> Result<(), Error> {
     let args: Vec<String> = env::args().collect();
-    let (suggestions_file, source_file) = match args.as_slice() {
-        [_, suggestions_file, source_file] => (suggestions_file, source_file),
+    let suggestions_file = match args.as_slice() {
+        [_, suggestions_file] => suggestions_file,
         _ => {
-            println!("USAGE: fix-json <suggestions-file> <source-file>");
+            println!("USAGE: fix-json <suggestions-file>");
             process::exit(1);
         }
     };
@@ -21,11 +21,21 @@ fn main() -> Result<(), Error> {
         rustfix::Filter::Everything,
     )?;
 
-    let source = fs::read_to_string(&source_file)?;
+    let mut files = HashMap::new();
+    for suggestion in suggestions {
+        let file = suggestion.solutions[0].replacements[0]
+            .snippet
+            .file_name
+            .clone();
+        let entry = files.entry(file).or_insert(Vec::new());
+        entry.push(suggestion);
+    }
 
-    let fixes = rustfix::apply_suggestions(&source, &suggestions)?;
-
-    println!("{}", fixes);
+    for (source_file, suggestions) in &files {
+        let source = fs::read_to_string(&source_file)?;
+        let fixes = rustfix::apply_suggestions(&source, suggestions)?;
+        fs::write(&source_file, fixes)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This is something I hacked together to allow me to automatically apply some clippy fixes. Not sure if this is something that is desired, but I thought I'd share in case others find it useful (eg see #130). Note that this overwrites the existing files. Also I know nothing about the json format for the suggestions, I'm probably making assumptions that I shouldn't.

My usage is:
```
cargo clippy --message-format json | jq .message | grep -v ^null > clippy.json
fix-json clippy.json
```