### PR TITLE
Fix string indexing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,15 @@ fn parse_snippet(span: &DiagnosticSpan) -> Option<Snippet> {
             std::cmp::min(indent, line.highlight_start)
         })
         .min()?;
+
+    let text_slice = span.text[0].text.chars().collect::<Vec<char>>();
+
+    // We subtract `1` because these highlights are 1-based
     let start = span.text[0].highlight_start - 1;
     let end = span.text[0].highlight_end - 1;
-    let lead = span.text[0].text[indent..start].to_string();
-    let mut body = span.text[0].text[start..end].to_string();
+    let lead = text_slice[indent..start].iter().collect();
+    let mut body: String = text_slice[start..end].iter().collect();
+
     for line in span.text.iter().take(span.text.len() - 1).skip(1) {
         body.push('\n');
         body.push_str(&line.text[indent..]);
@@ -118,12 +123,13 @@ fn parse_snippet(span: &DiagnosticSpan) -> Option<Snippet> {
     // If we get a DiagnosticSpanLine where highlight_end > text.len(), we prevent an 'out of
     // bounds' access by making sure the index is within the array bounds.
     let last_tail_index = last.highlight_end.min(last.text.len()) - 1;
+    let last_slice = last.text.chars().collect::<Vec<char>>();
 
     if span.text.len() > 1 {
         body.push('\n');
-        body.push_str(&last.text[indent..last_tail_index]);
+        body.push_str(&last_slice[indent..last_tail_index].iter().collect::<String>());
     }
-    tail.push_str(&last.text[last_tail_index..]);
+    tail.push_str(&last_slice[last_tail_index..].iter().collect::<String>());
     Some(Snippet {
         file_name: span.file_name.clone(),
         line_range: LineRange {

--- a/tests/edge-cases/utf8_idents.recorded.json
+++ b/tests/edge-cases/utf8_idents.recorded.json
@@ -1,0 +1,59 @@
+{
+  "message": "expected one of `,`, `:`, `=`, or `>`, found `'β`",
+  "code": null,
+  "level": "error",
+  "spans": [
+    {
+      "file_name": "./tests/everything/utf8_idents.rs",
+      "byte_start": 14,
+      "byte_end": 14,
+      "line_start": 2,
+      "line_end": 2,
+      "column_start": 6,
+      "column_end": 6,
+      "is_primary": false,
+      "text": [
+        {
+          "text": "    γ  //~ ERROR non-ascii idents are not fully supported",
+          "highlight_start": 6,
+          "highlight_end": 6
+        }
+      ],
+      "label": "expected one of `,`, `:`, `=`, or `>` here",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null
+    },
+    {
+      "file_name": "./tests/everything/utf8_idents.rs",
+      "byte_start": 145,
+      "byte_end": 148,
+      "line_start": 4,
+      "line_end": 4,
+      "column_start": 5,
+      "column_end": 7,
+      "is_primary": true,
+      "text": [
+        {
+          "text": "    'β, //~ ERROR non-ascii idents are not fully supported",
+          "highlight_start": 5,
+          "highlight_end": 7
+        }
+      ],
+      "label": "unexpected token",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null
+    }
+  ],
+  "children": [],
+  "rendered": "error: expected one of `,`, `:`, `=`, or `>`, found `'β`\n --> ./tests/everything/utf8_idents.rs:4:5\n  |\n2 |     γ  //~ ERROR non-ascii idents are not fully supported\n  |      - expected one of `,`, `:`, `=`, or `>` here\n3 |        //~^ WARN type parameter `γ` should have an upper camel case name\n4 |     'β, //~ ERROR non-ascii idents are not fully supported\n  |     ^^ unexpected token\n\n"
+}
+{
+  "message": "aborting due to previous error",
+  "code": null,
+  "level": "error",
+  "spans": [],
+  "children": [],
+  "rendered": "error: aborting due to previous error\n\n"
+}

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -19,3 +19,12 @@ fn out_of_bounds_test() {
             .unwrap();
     assert!(expected_suggestions.is_empty());
 }
+
+#[test]
+fn utf8_identifiers_test() {
+    let json = fs::read_to_string("./tests/edge-cases/utf8_idents.recorded.json").unwrap();
+    let expected_suggestions =
+        rustfix::get_suggestions_from_json(&json, &HashSet::new(), rustfix::Filter::Everything)
+            .unwrap();
+    assert!(expected_suggestions.is_empty());
+}


### PR DESCRIPTION
Previously rustfix was treating the highlight indices as byte offsets.
This caused it to crash when a highlight index was pointing inside a
multi-byte character.

This fix makes sure to index into the characters of the string instead
of the bytes.

Fixes https://github.com/rust-lang/rust/issues/59660