### PR TITLE
Update tests for `bare_trait_objects` warning.

### DIFF
--- a/tests/everything/E0178.fixed.rs
+++ b/tests/everything/E0178.fixed.rs
@@ -3,7 +3,7 @@
 trait Foo {}
 
 struct Bar<'a> {
-    w: &'a (Foo + Send),
+    w: &'a (dyn Foo + Send),
 }
 
 fn main() {

--- a/tests/everything/E0178.rs
+++ b/tests/everything/E0178.rs
@@ -3,7 +3,7 @@
 trait Foo {}
 
 struct Bar<'a> {
-    w: &'a Foo + Send,
+    w: &'a dyn Foo + Send,
 }
 
 fn main() {

--- a/tests/everything/closure-immutable-outer-variable.fixed.rs
+++ b/tests/everything/closure-immutable-outer-variable.fixed.rs
@@ -10,7 +10,7 @@
 
 // Point at the captured immutable outer variable
 
-fn foo(mut f: Box<FnMut()>) {
+fn foo(mut f: Box<dyn FnMut()>) {
     f();
 }
 


### PR DESCRIPTION
This should get tests passing on CI.

`bare_trait_objects` was made warn-by-default in https://github.com/rust-lang/rust/pull/61203.

E0178 can't fix both diagnostics because they overlap.
